### PR TITLE
Revised and simplified info for hosting a community meeting

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@ reviewers:
   - ankushagarwal
   - DjangoPeng
   - erikerlandson
+  - ewilderj
   - gaocegege
   - Jimexist
   - jlewi

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Welcome to Kubeflow! We're glad to have you here.
 
 [**Meeting calendar**](https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal version](https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com/public/basic.ics)).
 
+[Meeting notes](http://bit.ly/kf-meeting-notes/).
+
 If your group has a regular meeting, talk to
 [@ewilderj](https://github.com/ewilderj) about getting it added to the calendar.
 

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ race, religion, or sexual identity and orientation.
 The Kubeflow community is guided by our [Code of
 Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md),
 which we encourage everybody to read before participating.
+
+## About this repository
+
+* [proposals](https://github.com/kubeflow/community/tree/master/proposals): Kubeflow design proposals
+* [how-to](https://github.com/kubeflow/community/tree/master/how-to): for documenting community and other project processes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Kubeflow! We're glad to have you here.
 
 [**Meeting calendar**](https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal version](https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com/public/basic.ics)).
 
-[Meeting notes](http://bit.ly/kf-meeting-notes/).
+[Meeting notes](http://bit.ly/kf-meeting-notes).
 
 If your group has a regular meeting, talk to
 [@ewilderj](https://github.com/ewilderj) about getting it added to the calendar.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Kubeflow Community
+
+Welcome to Kubeflow! We're glad to have you here.
+
+## Community meetings
+
+[**Meeting calendar**](https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal version](https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com/public/basic.ics)).
+
+If your group has a regular meeting, talk to
+[@ewilderj](https://github.com/ewilderj) about getting it added to the calendar.
+
+### Kubeflow community call
+
+The project team holds a weekly community call on Tuesdays. This call alternates
+weekly between US East/EMEA and US West/APAC friendly times. Joining the
+[kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+mailing list will automatically send you calendar invitations for the meetings, or you can subscribe to the community meeting calendar above.
+
+
+Agenda, notes, and a reminder of the next call are sent to the kubeflow-discuss
+mailing list.
+
+
+## Forums and discussion
+
+| Topic                                                           | Mailing list                                                                      | Slack                                                                                             |
+| :----                                                           | :------------                                                                     | :-------------                                                                                    |
+| General discussion                                       | [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)      | [#general](https://kubeflow.slack.com/messages/C7REE0EHK)                                         |
+| TF Operator ([Github](https://github.com/kubeflow/tf-operator)) | [tf-operator](https://groups.google.com/a/kubeflow.org/forum/#!forum/tf-operator) | [#tf-operator](https://kubeflow.slack.com/messages/https://kubeflow.slack.com/messages/C985VJN9F) |
+| Community meeting chat                                          | n/a                                                                               | [#community](https://kubeflow.slack.com/messages/C8Q0QJYNB)                                       |
+
+Slack server: [kubeflow.slack.com](https://kubeflow.slack.com/)
+
+## Code of conduct
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+The Kubeflow community is guided by our [Code of
+Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md),
+which we encourage everybody to read before participating.

--- a/how-to/community_meetings.md
+++ b/how-to/community_meetings.md
@@ -76,12 +76,16 @@ Ensure that action items that people have agreed to are clearly noted.
   easiest way to do this is highlight and add a comment tagging their email
   address with a `+` sign.
   
-* When Zoom emails you to say the audio recording is available, get the share
-  link for the audio recording and insert it at the top of the doc. (If there is
-  a video recording, I usually delete this as it's not a lot of use and takes up
-  space.)
+* For Zoom owners: when Zoom emails you to say the audio recording is available,
+  get the share link for the audio recording and insert it at the top of the
+  doc. (If there is a video recording, I usually delete this as it's not a lot
+  of use and takes up space.)
   
-* Circulate the notes link to the mailing list. 
+* Ask the Zoom owner to add the link if they haven't done already.
+  
+* Circulate the notes link to the mailing list, and include some highlights in
+  the message so people can figure out if they want to read the notes or listen
+  to the recording.
   
 ## That's it!
 

--- a/how-to/community_meetings.md
+++ b/how-to/community_meetings.md
@@ -4,84 +4,44 @@ Author(s): Edd Wilder-James [@ewilderj](http://github.com/ewilderj)
 
 ## Prerequisites
 
-* A paid [Zoom](http://zoom.us/) account. At the time of writing, a "Pro" level account should be sufficient.
+* You should be a member of the [community-meeting-hosts@](https://groups.google.com/a/kubeflow.org/forum/#!forum/community-meeting-hosts) group. 
 
 ## Setting up the meeting
 
-For a meeting that already exists, get yourself added as a host from the Zoom
-interface. Contact the relevant meeting organizer:
-
-* Main community meeting: [@ewilderj](mailto:ewj@google.com) 
+* Ensure that somebody with Zoom recording permissions will join. Currently,
+  this is either Edd Wilder-James or Michelle Casbon.
 
 No less than 24 hours before the meeting, circulate the agenda and notes Google
 doc:
 
-1. Create a Google doc, make it public viewable, and editable by
-   *kubeflow-discuss@googlegroups.com*, this will allow the community members to
-   help you crowdsource notes. Please note that you cannot make a Google Doc
-   public viewable from some corporate accounts, e.g. google.com, so using a
-   personal Gmail account might be necessary.
+1. This Google doc is hosted at
+   [bit.ly/kf-meeting-notes](http://bit.ly/kf-meeting-notes) and is editable by
+   members of
+   [community-meeting-hosts@](https://groups.google.com/a/kubeflow.org/forum/#!forum/community-meeting-hosts).
+   It is viewable by the public, and anybody subscribed to
+   [kubeflow-discuss@](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+   may make comments and suggest changes.
    
-2. Bring the agenda items in (usually queued from the week's previous calls, or
-   suggested for discussion on the mailing list) at the top
+2. Copy the template agenda from the bottom, add your name as host, then
+   incorporate agenda items. Agenda items are queued up on the first page of the
+   doc. Be sure to bring up action items from the previous meeting into their
+   own section at the top.
    
 3. Circulate the agenda document to the mailing list, along with a reminder of
-   the Zoom call in details. You can get these from the Zoom interface.
-
-## Creating a new meeting in Zoom
-
-A few guidelines:
-
-* Be sensitive to the timezone of your participants. If there's no one good
-  time, rotate your meeting through two options (e.g. 8am PT & 4pm PT)
-
-* Configure the meeting to be recorded, so you can share audio afterwards
-
-* To keep the same meeting ID every time, mark the meeting as recurring. If your
-  meeting doesn't have a regular time, you can still keep the same meeting ID by
-  not specifying a schedule.
-  
-* Ensure your meeting is configured with both phone dial-in and audio
-  conferencing capability.
-
-* Send a calendar invite to the participating group (usually a mailing list). In
-  the invitation, include both the Zoom URL and dial-in details for the most
-  common regions in your meeting. This info is available to cut and paste from
-  the Zoom interface. Here's an example description:
-
-```
-Join from PC, Mac, Linux, iOS or Android: https://zoom.us/j/799749911
-
-Or iPhone one-tap:
-US: +16699006833,,799749911# or +16465588656,,799749911# 
-Or Telephone:
-Dial (for higher quality, dial a number based on your current location): 
-US: +1 669 900 6833 or +1 646 558 8656 
-France: +33 (0) 1 8288 0188 
-Germany: +49 (0) 30 3080 6188 
-Ireland: +353 (0) 1 691 7488 
-United Kingdom: +44 (0) 20 3695 0088 
-South Korea: +82 (0) 2 6022 2322 
-Japan: +81 (0) 3 4578 1488 
-Malaysia: +60 3 9212 1727 
-Singapore: +65 3158 7288 
-Australia: +61 (0) 2 8015 2088 
-New Zealand: +64 (0) 9 801 1188 or +64 (0) 4 831 8959 
-Hong Kong: +852 5808 6088 
-Meeting ID: 799 749 911
-International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
-```
+   the Zoom call in details. You can get these from previous messages, as they
+   remain constant.
 
 ## Running the meeting
 
-Start the Zoom meeting 5 minutes before its assigned time.  The meeting should
-be configured that new arrivals are muted by default, to reduce noise.  Usually,
-you'll need to tell people at the start time that you'll wait a couple of
-minutes to allow everybody 
-to arrive.
+Arrive to the meeting at least 5 minutes before its assigned time. The meeting
+should be configured that new arrivals are muted by default, to reduce noise.
+Usually, you'll need to tell people at the start time that you'll wait a couple
+of minutes to allow everybody to arrive.
 
 Post a link to the agenda & notes into the relevant Slack channel: for the main
 community meeting, this is *#community*.
+
+Ensure that the person responsible for Zoom recording has started the recording.
 
 Kick off by welcoming people, reminding them of the Slack channel for feedback,
 and the link for agenda/notes. Hand off to the team member driving the agenda,
@@ -99,11 +59,12 @@ Remind people of some good practices:
 
 * Folks should add relevant links and info into the meeting doc, rather than the
   Zoom channel, as the Zoom chat will go away at the end of the meeting.
-  
+
 ## Taking notes
 
 If you are not going to be the note-taker, ensure there is a designated
-volunteer to take notes before discussion starts.
+volunteer to take notes before discussion starts. They should have edit
+permissions for the notes doc.
 
 Ensure that action items that people have agreed to are clearly noted.
 
@@ -121,11 +82,6 @@ Ensure that action items that people have agreed to are clearly noted.
   space.)
   
 * Circulate the notes link to the mailing list. 
-
-* Leave the doc editable for a few hours for incoming amendments, then change
-  the sharing so the group has *Comment & Suggest* permissions. This is to avoid
-  us having worry about after-the-fact changes that the community doesn't get
-  notified of.
   
 ## That's it!
 


### PR DESCRIPTION
This updates the doc to remove unneeded details about setting up Zoom, and adjusts for the fact that the meeting notes now have a constant URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/36)
<!-- Reviewable:end -->
