### PR TITLE
Replace starter label with good first issue

### DIFF
--- a/issue-labels.md
+++ b/issue-labels.md
@@ -9,7 +9,7 @@ GitHub Issues are tagged with a standard set of labels across all kubeflow repos
 | *none*      | do-not-merge
 |             | duplicate
 |             | high-impact
-|             | starter
+|             | good first issue
 |             | testing
 |             | wont-fix
 | addition    | feature


### PR DESCRIPTION
to reflect the [GitHub-wide standard](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/).

Resolves #12.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/40)
<!-- Reviewable:end -->
