### PR TITLE
Add tf-operator v1alpha2 design proposal into accepted-proposals

### DIFF
--- a/accepted-proposals.md
+++ b/accepted-proposals.md
@@ -2,3 +2,7 @@
 #### Proposal Title
 * Short description
 * Link to proposal markdown file in the `proposals` directory
+
+#### TF-Operator Design (v1alpha2)
+* Move the version of tf-operator API to `v1alpha2`.
+* [Proposal](./proposals/tf-operator-design-v1alpha2.md).


### PR DESCRIPTION
Hi, as https://github.com/kubeflow/community/pull/30 merged, update the `accepted-proposals` for quick search.

@jlewi @gaocegege PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/42)
<!-- Reviewable:end -->
