### PR TITLE
Start a directory to keep track of contact information for members

### DIFF
--- a/members.yaml
+++ b/members.yaml
@@ -1,0 +1,17 @@
+# This file is used to provide a mapping between various ids of members
+# in the community.
+# It is entirely opt in. The only required field is github id.
+#
+# Please keep sorted by github id.
+# For slack please use the id on kubeflow.slack.com
+# For email corporate/professional email addresses are preferred.
+#
+# Individuals should only add their information and not that of other
+# people.
+
+- github: jlewi
+  slack: jlewi
+  firstName: Jeremy
+  lastName: Lewi
+  affiliation: Google
+  email: jlewi@google.com


### PR DESCRIPTION
This is entirely optional.

Immediate use case is to make it easy to map ids between various systems.

Fix #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/58)
<!-- Reviewable:end -->
