### PR TITLE
Create a list of companies/organizations contributing to Kubeflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,5 @@
 # Kubeflow Contributor Guide
 
-Our PR workflow is nearly identical to Kubernetes'. Much of this doc is a
-modified version of Kubernetes' [contributors](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md)
-and [owners](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#code-review-using-owners-files)
-guides.
-
 ## Welcome
 
 Welcome to the Kubeflow project! This document is the single source of truth
@@ -17,7 +12,7 @@ you find something is missing or incorrect.
 -   [Your First Contribution](#your-first-contribution)
     -   [Find something to work on](#find-something-to-work-on)
     -   [Starter issues](#starter-issues)
--   [Owners](#owners)
+-   [Owners files and PR workflow](#owners)
     -   [Overview of OWNERS files](#overview-of-owners-files)
         -   [OWNERS](#owners-1)
         -   [OWNERS_ALIASES](#owners_aliases)
@@ -66,8 +61,34 @@ the following tags:
 * [`help wanted`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Akubeflow+archived%3Afalse+label%3A%22help+wanted%22)
 * [`starter`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+org%3Akubeflow+archived%3Afalse+label%3A%22starter%22)
 
+# Joining the community
 
-# Owners
+Follow these instructions if
+
+* You want to become a member of the Kubeflow GitHub org (so you can trigger tests)
+* Become part of the Kubeflow build cop or release teams
+* Be recognized as an individual or organization as contributing to Kubeflow
+
+## Individual contributors
+
+Please send a PR adding yourself to [members](https://github.com/kubeflow/community/blob/master/members.yaml)
+
+  * The only **required** field is your GitHub id
+  * This is a **prerequisite** for joining the GitHub org
+
+## Companies/Organizations
+
+If you would like your company or organization to be acknowledged for contributing to
+Kubeflow or participatng in the community (being a user counts) please send a PR
+adding the relevant info to[member_organizations.yaml](https://github.com/kubeflow/community/blob/master/member_organizations.yaml).
+
+
+# Owners files and PR workflow
+
+Our PR workflow is nearly identical to Kubernetes'. Most of these instructions are a
+modified version of Kubernetes' [contributors](https://github.com/kubernetes/community/blob/master/contributors/guide/README.md)
+and [owners](https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#code-review-using-owners-files)
+guides.
 
 ## Overview of OWNERS files
 

--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -1,0 +1,27 @@
+# This file provides information about companies/organizations
+# that would like to be aknowledged as contributing/participating in
+# Kubeflow.
+#
+# Required fields:
+#   name - The name of the company or organization.
+#   contacts - A list of email addresses for the primary contacts for
+#     the organization.
+#
+# Optional fields
+#    url - Url for the organization 
+#    hiringForKubeflow - true/false whether the orgniazation is hiring for Kubeflow related
+#      positions
+#    hiringUrl - A URL for potential job applicants.
+#
+# We do not infer organizations based on affiliation in members.yaml because
+# some members may be contributing as individuals and not part of a deeper involvement
+# with Kubeflow for their company/organization.
+
+- name: Google
+  contacts:
+    - aronchick@google.com
+    - ewj@google.com
+    - jlewi@google.com
+  url: https://cloud.google.com/products/machine-learning/
+  hiringForKubeflow: true
+  hiringUrl: https://goo.gl/Q85pzF

--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -1,5 +1,5 @@
 # This file provides information about companies/organizations
-# that would like to be aknowledged as contributing/participating in
+# that would like to be acknowledged as contributing/participating in
 # Kubeflow.
 #
 # Required fields:


### PR DESCRIPTION
Start a file to keep track of organizations participating in Kubeflow.

* With Kubeflow around the corner we want to be sure to aknowledge the
  companies/organizations who are participating in Kubeflow.

* I think starting a file in source control is the best way to manage
  this over time.

/cc @ddysher @mattf @ewilderj @aronchick @elsonrodriguez @inc0 @willingc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/63)
<!-- Reviewable:end -->
