### PR TITLE
Add Intel to member organisations

### DIFF
--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -28,6 +28,13 @@
   hiringForKubeflow: true
   hiringUrl: https://caicloud.io/jobs
 
+- name: Intel
+  contacts:
+    - michal.jastrzebski@intel.com
+    - jose.g.aguirre@intel.com
+    - balaji.subramaniam@intel.com
+  url: https://www.intel.com
+
 - name: Github
   contacts:
     - hamelsmu@github.com
@@ -61,10 +68,3 @@
   url: https://www.weave.works/blog/kubeflow-and-weave-cloud
   hiringForKubeflow: true
   hiringUrl: https://www.weave.works/company/hiring/
-
-- name: Intel
-  contacts:
-    - michal.jastrzebski@intel.com
-    - jose.g.aguirre@intel.com
-    - balaji.subramaniam@intel.com
-  url: https://www.intel.com

--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -61,3 +61,10 @@
   url: https://www.weave.works/blog/kubeflow-and-weave-cloud
   hiringForKubeflow: true
   hiringUrl: https://www.weave.works/company/hiring/
+
+- name: Intel
+  contacts:
+    - michal.jastrzebski@intel.com
+    - jose.g.aguirre@intel.com
+    - balaji.subramaniam@intel.com
+  url: https://www.intel.com


### PR DESCRIPTION
I've put top contributors of kubeflow projects (kubeflow, tf-operator/pytorch-operator and kvc). If any of my fellow Intelees would want to be added to list, feel free to ping me or just hijack PR and add yourself:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/81)
<!-- Reviewable:end -->
