### PR TITLE
Tidy Red Hat's entry in the organization list.

### DIFF
--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -94,10 +94,6 @@
 - name: Red Hat
   contacts:
     - matt@redhat.com
-    - mhausenb@redhat.com
-    - pmackinn@redhat.com
-    - tmckay@redhat.com
-    - willb@redhat.com
   url: https://www.redhat.com
 
 - name: Weaveworks


### PR DESCRIPTION
This commit removes contact information for Red Hat Kubeflow participants, keeping just Red Hat's point of contact for Red Hat's involvement in the Kubeflow community.

(Per Jeremy's recent message on kubeflow-discuss.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/95)
<!-- Reviewable:end -->
