### PR TITLE
Remove Jose from Intel, add Kam and Ebi to Intel

### DIFF
--- a/member_organizations.yaml
+++ b/member_organizations.yaml
@@ -120,8 +120,9 @@
 - name: Intel
   contacts:
     - michal.jastrzebski@intel.com
-    - jose.g.aguirre@intel.com
+    - kam.d.kasravi@intel.com
     - balaji.subramaniam@intel.com
+    - abolfazl.shahbazi@intel.com
   url: https://www.intel.com
 
 - name: Microsoft

--- a/members.yaml
+++ b/members.yaml
@@ -30,7 +30,7 @@
   lastName: Prosvirov
   affiliation: Cisco
   email: kprosvir@cisco.com
- 
+
 - github: amsaha
   slack: amsaha
   firstName: Amit
@@ -44,8 +44,8 @@
   lastName: Unruh
   affiliation: Google
   email: amyu@google.com
-  
-- github: andreyvelich  
+
+- github: andreyvelich
   slack: andreyvelich
   firstName: Andrey
   lastName: Velichkevich
@@ -58,6 +58,13 @@
   lastName: Agarwal
   affiliation: Google
   email: agwl@google.com
+
+- github: ashahba
+  slack: ashahba
+  firstName: Ebi
+  lastName: Shahbazi
+  affiliation: Intel
+  email: abolfazl.shahbazi@intel.com
 
 - github: bharaththiruveedula
   slack: tbh
@@ -93,7 +100,7 @@
   lastName: Dutta
   affiliation: Cisco
   email: dedutta@cisco.com
-  
+
 - github: deepermind
   slack: jinanzhou
   firstName: Jinan
@@ -156,7 +163,7 @@
   lastName: Pan
   affiliation: Google
   email: yangpa@google.com
-  
+
 - github: jinxingwang
   slack: willWang
   firstName: Will
@@ -185,7 +192,7 @@
   affiliation: None
   email: jwwandy@gmail.com
 
-- github: jzp1025 
+- github: jzp1025
   slack: jzp1025
   firstName: Zongpei
   LastName: Jiang
@@ -213,7 +220,7 @@
   affiliation: Red Hat
   email: mhausenb@redhat.com
 
-- github: netankit  
+- github: netankit
   slack: ankit
   firstName: Ankit
   lastName: Bahuguna
@@ -276,7 +283,7 @@
   affiliation: Groupon
   email: scasey@groupon.com
 
-- github: suleisl2000 
+- github: suleisl2000
   slack: suleisl2000
   firstName: Lei
   LastName: Su


### PR DESCRIPTION
@jlewi Jose is at `Nike`, but I don't have his contact info.
I also added both myself and @kkasravi to the list of Intel folks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/211)
<!-- Reviewable:end -->
