### PR TITLE
Aggressively pruning the OWNERs file to better auto-assign reviewers.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,5 @@
 approvers:
   - abhi-g
-  - aronchick
-  - DjangoPeng
-  - ewilderj
   - jlewi
-  - mattf
-  - texasmichelle
-reviewers:
-  - aronchick
-  - DjangoPeng
-  - erikerlandson
-  - ewilderj
-  - gaocegege
-  - Jimexist
-  - jlewi
-  - lluunn
-  - ScorpioCPH
-  - texasmichelle
-  - willingc
-  - zabbasi
+  - richardsliu
+  - theadactyl

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - lluunn
+  - zabbasi


### PR DESCRIPTION
* This is solely an effort to ensure auto-assigned reviewers are better
  chosen.

* I don't believe any of the removed folks have been active reviewers
  but if they are I'll gladly accept a PR adding them back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/251)
<!-- Reviewable:end -->
