### PR TITLE
Update calendar_import script and add kubecon events.

### DIFF
--- a/calendar.yaml
+++ b/calendar.yaml
@@ -1,15 +1,16 @@
-# This file lists all the meetings to be listed on the Kubeflow
-# Community Calendar (https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com).
+# This file lists all the meetings to be listed on the Kubeflow Community
+# Calendar (https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com).
 #
 # Required fields:
-#   id - A unique ID to give the meeting (add 1 to the previous meeting ID in the list).
+#   id - A unique ID to give the meeting (add 1 to the previous meeting ID in
+#   the list).
 #   name - The name of the meeting.
 #   date - The date of the first meeting (month/day/year).
 #   time - The start and end of the meeting in PST time zone.
 #   frequency - How often the meeting takes place.
 #   video - Zoom or Hangouts meeting link.
 #   description - Any other information about the meeting such
-#   as the meeting agenda link. 
+#   as the meeting agenda link.
 #   organizer - Github username of the meeting organizer.
 
 - id: kf001
@@ -18,13 +19,13 @@
   time: 8:00AM-8:55AM
   frequency: bi-weekly
   video: https://zoom.us/j/799749911
-  description: 
+  description:
     - |
       Notes & agenda: https://bit.ly/kf-meeting-notes
 
       Join from PC, Mac, Linux, iOS or Android: https://zoom.us/j/799749911
 
-      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656 
+      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656
       International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: theadactyl
 
@@ -34,13 +35,13 @@
   time: 5:30PM-6:25PM
   frequency: bi-weekly
   video: https://zoom.us/j/799749911
-  description: 
+  description:
     - |
       Notes & agenda: https://bit.ly/kf-meeting-notes
 
       Join from PC, Mac, Linux, iOS or Android: https://zoom.us/j/799749911
 
-      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656 
+      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656
       International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: theadactyl
 
@@ -87,3 +88,163 @@
     - |
       Meeting Logs: http://bit.ly/kf-outreach-meeting-notes
   organizer: theadactyl
+
+- id: kf007
+  name: Google OSS Hands-on Workshop B - Kubeflow (MLOPS) @ Kubecon
+  date: 11/18/2019
+  time: 1:00pm-3:00pm
+  description:
+    - |
+      Kubecon schedule link: https://sched.co/W536
+      Requires additional registration & Fee
+  organizer: jlewi
+
+- id: kf008
+  name: Enabling Kubeflow with Enterprise-Grade Auth for On-Prem Deployments - Yannis Zarkadas, Arrikto & Krishna Durai, Cisco 
+  date: 11/19/2019
+  time: 11:50am-12:25pm
+  description:
+    - |
+      Room 16AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaY4
+  organizer: jlewi
+
+- id: kf009
+  name: "Introducing KFServing: Serverless Model Serving on Kubernetes - Ellis Bigelow, Google & Dan Sun, Bloomberg"
+  date: 11/19/2019
+  time: 2:25pm-3:00pm
+  description:
+    - |
+      Room 15AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaZo
+  organizer: jlewi
+
+- id: kf010
+  name: Towards Continuous Computer Vision Model Improvement with Kubeflow - Derek Hao Hu & Yanjia Li, Snap Inc.
+  date: 11/19/2019
+  time: 3:20pm-3:55pm
+  description:
+    - |
+      Room 31ABC - San Diego Convention Center Upper Level
+      https://sched.co/Uae4
+  organizer: jlewi
+
+- id: kf011
+  name: Measuring and Optimizing Kubeflow Clusters at Lyft - Konstantin Gizdarski, Lyft & Richard Liu, Google
+  date: 11/19/2019
+  time: 4:25pm-5:00pm
+  description:
+    - |
+      Room 6C - San Diego Convention Center Upper Level
+      https://sched.co/UabJ
+  organizer: jlewi
+
+- id: kf012
+  name: "KubeFlow’s Serverless Component: 10x Faster, a 1/10 of the Effort - Orit Nissan-Messing, Iguazio"
+  date: 11/19/2019
+  time: 4:25pm-5:00pm
+  description:
+    - |
+      Room 6F - San Diego Convention Center Upper Level
+      https://sched.co/UaaL
+  organizer: jlewi
+
+- id: kf013
+  name: Advanced Model Inferencing Leveraging KNative, Istio and Kubeflow Serving - Animesh Singh, IBM & Clive Cox, Seldon
+  date: 11/20/2019
+  time: 10:55am-11:30am
+  description:
+    - |
+      Room 17AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaVw
+  organizer: jlewi
+
+- id: kf014
+  name: Building and Managing a Centralized Kubeflow Platform at Spotify - Keshi Dai & Ryan Clough, Spotify
+  date: 11/20/2019
+  time: 11:50am-12:25pm
+  description:
+    - |
+      Room 29ABCD - San Diego Convention Center Upper Level
+      https://sched.co/UaWi
+  organizer: jlewi
+
+- id: kf015
+  name: "Panel: Enterprise-grade, On-prem Kubeflow in the Financial Sector - Laura Schornack, JPMorgan Chase; Jeff Fogarty, US Bank; Josh Bottum, Arrikto; & Thea Lamkin, Google"
+  date: 11/20/2019
+  time: 2:25pm-3:00pm
+  description:
+    - |
+      Room 14AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaYA
+  organizer: jlewi
+
+- id: kf016
+  name: "Kubeflow: Multi-Tenant, Self-Serve, Accelerated Platform for Practitioners - Kam Kasravi, Intel & Kunming Qu, Google"
+  date: 11/20/2019
+  time: 3:20pm-3:55pm
+  description:
+    - |
+      Room 17AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaaI
+  organizer: jlewi
+
+- id: kf017
+  name: "Realizing End to End Reproducible Machine Learning on Kubernetes - Suneeta Mall, Nearmap"
+  date: 11/20/2019
+  time: 4:25pm-5:00pm
+  description:
+    - |
+      Room 16AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UacQ
+  organizer: jlewi
+
+- id: kf018
+  name: "Tutorial: From Notebook to Kubeflow Pipelines: An End-to-End Data Science Workflow - Michelle Casbon, Google, Stefano Fioravanzo, Fondazione Bruno Kessler, & Ilias Katsakioris, Arrikto (Limited Available Seating; First-Come, First-Served Basis)"
+  date: 11/21/2019
+  time: 2:25pm-3:55pm
+  description:
+    - |
+      Room 28ABCDE - San Diego Convention Center Upper Level
+      https://sched.co/UaaL
+  organizer: jlewi
+
+- id: kf019
+  name: "Building a Medical AI with Kubernetes and Kubeflow - Jeremie Vallee, Babylon Health"
+  date: 11/21/2019
+  time: 3:20pm-3:55pm
+  description:
+    - |
+      Room 11AB - San Diego Convention Center Upper Level
+      https://sched.co/UaWf
+  organizer: jlewi
+
+- id: kf020
+  name: "KubeDirector - Deploying Complex Stateful Applications on Kubernetes - Joel Baxter & Thomas Phelan, Hewlett Packard Enterprise"
+  date: 11/21/2019
+  time: 4:25pm-5:00pm
+  description:
+    - |
+      Ballroom Sec 20CD - San Diego Convention Center Upper Level
+      https://sched.co/UaaF
+  organizer: jlewi
+
+- id: kf021
+  name: "GPU as a Service Over K8s: Drive Productivity and Increase Utilization - Yaron Haviv, Iguazio"
+  date: 11/21/2019
+  time: 4:25pm-5:00pm
+  description:
+    - |
+      Room 17AB - San Diego Convention Center Mezzanine Level
+      https://sched.co/UaYt
+  organizer: jlewi
+
+- id: kf022
+  name: "Supercharge Kubeflow Performance on GPU Clusters - Meenakshi Kaushik & Neelima Mukiri, Cisco"
+  date: 11/21/2019
+  time: 5:20pm-5:55pm
+  description:
+    - |
+      Room 11AB - San Diego Convention Center Upper Level
+      https://sched.co/Uada
+  organizer: jlewi

--- a/scripts/calendar_import.py
+++ b/scripts/calendar_import.py
@@ -1,84 +1,173 @@
-#!/usr/bin/env python
+"""
+Imports meetings in 'calendar.yaml' to the Kubeflow Community Calendar
+For modifications please refer to the Google Calendar Python API:
+https://developers.google.com/resources/api-libraries/documentation/calendar/v3/python/latest/calendar_v3.events.html#insert
 
-# Imports meetings in 'calendar.yaml' to the Kubeflow Community Calendar
-# For modifications please refer to the Google Calendar Python API:
-# https://developers.google.com/resources/api-libraries/documentation/calendar/v3/python/latest/calendar_v3.events.html#insert
+Requires the following packages: oauth2client, pyyaml, google-api-python-client
 
+Uses a service account -- the calendar must be shared with the service account
+email and given permission: "Make changes to events"
+
+References:
+  https://developers.google.com/calendar/quickstart/python
+    * Shows the web app flow
+  https://developers.google.com/calendar/auth
+"""
 from datetime import datetime
+import fire
 import logging
-import os.path
+import os
 import yaml
 import googleapiclient.errors
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google_auth_oauthlib import flow
+from google.auth.transport import requests
+from oauth2client import service_account
+from pathlib import Path
+import pickle
+import json
+
+# The public address of the kubeflow.org calendar
+CALENDAR_ID = 'kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com'
 
 SCOPES = ['https://www.googleapis.com/auth/calendar.events']
 
-def main():
-  logging.getLogger().setLevel(logging.INFO)
-  flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
-  creds = flow.run_local_server(port=0)
-  service = build('calendar', 'v3', credentials=creds)
+class CalendarUpdater:
+  """Class to update the calendar"""
 
-  this_file = __file__
-  repo_root = os.path.abspath(os.path.join(os.path.dirname(this_file), ".."))
-  cal_yaml = os.path.join(repo_root, "calendar.yaml")
+  def sync(self, oauth_client_secret=None):
+    """Sync the events in the YAML file to the calendar
 
-  with open(cal_yaml) as cal:
-    meetings = yaml.safe_load(cal)
+    Args:
+      oauth_client_secret: Path to the json file containing an OAuth client id
+        for an OAuth application to use the Calendar API.
+    """
+    home = str(Path.home())
+    config_dir = os.path.join(home, ".config", "kubeflow", "calendar_import")
+    if not os.path.exists(config_dir):
+      os.makedirs(config_dir)
 
-    for meeting in meetings:
-      date = meeting['date']
-      time_start, time_end = meeting['time'].split('-')
-      day_of_week = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%A').upper()[0:2]
-      start_datetime = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
-      end_datetime = datetime.strptime("{} {}".format(date, time_end), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
-      rec = 'RRULE:FREQ={};BYDAY={}'.format(meeting['frequency'].upper(), day_of_week)
+    # File to store credentials
+    credentials_file = os.path.join(config_dir, "token.pickle")
 
-      if meeting['frequency'] == "bi-weekly":
-          rec += ';INTERVAL=2'
-          rec = rec.replace('BI-WEEKLY', 'WEEKLY')
-      if meeting['frequency'] == "monthly":
-          rec = rec.replace('WEEKLY', 'MONTHLY')
+    # TODO(jlewi): Don't hardcode this
+    if not oauth_client_secret:
+      oauth_client_secret = os.path.join(home, "secrets",
+                                         "kf-calendar.oauth_client.json")
+      logging.info("Oauth_client_secret not set trying default: %s",
+                   oauth_client_secret)
 
-      event = {
-        'summary': meeting['name'],
-        'id': meeting['id'],
-        'location': meeting['video'],
-        'description': meeting['description'],
-        'start': {
-          'dateTime': start_datetime,
-          'timeZone': 'America/Los_Angeles',
-        },
-        'end': {
-          'dateTime': end_datetime,
-          'timeZone': 'America/Los_Angeles',
-        },
-        'recurrence': [rec],
-        'guestsCanSeeOtherGuests': 'false',
-        'reminders': {
-          'useDefault': False,
-          'overrides': [
-            {'method': 'popup', 'minutes': 10},
-          ],
-        },
-        "creator": {
-          "displayName": "Kubeflow",
-          "email": "kubeflow-discuss@googlegroups.com",
-        },
-        "organizer": {
-          "displayName": meeting['organizer'],
-        },
-      }
-
-      try:
-        event = service.events().insert(calendarId='primary', body=event).execute()
-        logging.info("Event created: {}".format(event.get('htmlLink')))
-      except googleapiclient.errors.HttpError:
-        event= service.events().update(calendarId='primary', eventId=meeting['id'], body=event).execute()
-        logging.info("Event updated: {}".format(event.get('htmlLink')))
+    # Since we are using the Google calendar API which isn't a Google Cloud API
+    # we can't use Google Cloud Platform Default Application credentials.
+    # There are two modes we want to support
+    # 1. Running locally using a personal account
+    # 2. Running in a cluster using a service account
+    # TODO(jlewi): Can we use Workload Identity with the calendar API or do
+    # we have to use a service account
+    creds = None
+    # The file token.pickle stores the user's access and refresh tokens, and is
+    # created automatically when the authorization flow completes for the first
+    # time.
+    if os.path.exists(credentials_file):
+      with open(credentials_file, 'rb') as token:
+        creds = pickle.load(token)
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+      if creds and creds.expired and creds.refresh_token:
+        creds.refresh(requests.Request())
       else:
-        logging.error("Error occurred creating the event")
+        if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+          # TODO(jlewi): How do we obtain credentials with a service account?
+          SERVICE_ACCOUNT_FILE = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
+          creds = service_account.ServiceAccountCredentials.from_json_keyfile_name(
+            SERVICE_ACCOUNT_FILE, SCOPES)
+        else:
+          web_flow = flow.InstalledAppFlow.from_client_secrets_file(oauth_client_secret,
+                                                                    SCOPES)
+          creds = web_flow.run_local_server(port=0)
 
-if __name__ == '__main__':
-    main()
+        # Save the credentials for the next run
+        with open(credentials_file, 'wb') as token:
+          pickle.dump(creds, token)
+
+    service = build('calendar', 'v3', credentials=creds)
+
+    this_file = __file__
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(this_file), ".."))
+    cal_yaml = os.path.join(repo_root, "calendar.yaml")
+
+    with open(cal_yaml) as cal:
+      meetings = yaml.safe_load(cal)
+
+      for meeting in meetings:
+        date = meeting['date']
+        time_start, time_end = meeting['time'].split('-')
+        day_of_week = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%A').upper()[0:2]
+        start_datetime = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
+        end_datetime = datetime.strptime("{} {}".format(date, time_end), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
+
+        event = {
+          'summary': meeting['name'],
+          'id': meeting['id'],
+          'location': meeting.get("video"),
+          'description': meeting['description'],
+                'start': {
+                    'dateTime': start_datetime,
+                    'timeZone': 'America/Los_Angeles',
+                    },
+                  'end': {
+                    'dateTime': end_datetime,
+                    'timeZone': 'America/Los_Angeles',
+                    },
+                  'guestsCanSeeOtherGuests': 'false',
+                  'reminders': {
+                    'useDefault': False,
+                          'overrides': [
+                        {'method': 'popup', 'minutes': 10},
+                      ],
+                      },
+                  "creator": {
+                          "displayName": "Kubeflow",
+                      "email": "kubeflow-discuss@googlegroups.com",
+                    },
+                        "organizer": {
+                      "displayName": meeting['organizer'],
+                    },
+        }
+
+
+        if meeting.get("frequency"):
+          rec = 'RRULE:FREQ={};BYDAY={}'.format(meeting['frequency'].upper(), day_of_week)
+
+          if meeting['frequency'] == "bi-weekly":
+            rec += ';INTERVAL=2'
+            rec = rec.replace('BI-WEEKLY', 'WEEKLY')
+          if meeting['frequency'] == "monthly":
+            rec = rec.replace('WEEKLY', 'MONTHLY')
+
+          event["recurrence"] = [rec]
+
+        try:
+          event = service.events().insert(calendarId=CALENDAR_ID, body=event).execute()
+          logging.info("Event created: {}".format(event.get('htmlLink')))
+        except googleapiclient.errors.HttpError as e:
+          content = json.loads(e.content)
+
+          if (content.get("error", {}).get("code") ==
+              requests.requests.codes.CONFLICT):
+            # It already exists so issue an update instead
+            event = service.events().update(calendarId=CALENDAR_ID, eventId=meeting['id'],
+                                            body=event).execute()
+          logging.info("Event updated: {}".format(event.get('htmlLink')))
+        except Exception as e:
+          logging.error("Error occurred creating the event: ", e)
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                                '|%(pathname)s|%(lineno)d| %(message)s'),
+                        datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  fire.Fire(CalendarUpdater)
+


### PR DESCRIPTION
* Pull in the changes in kubeflow/community#288

* Use pyfire in calendar_import.py so we can take command line arguments

* Add a command line argument to specify the path of the json file containing
  the OAuth id that is used with the calendar API

* Add functionality to support saving the credentials in the home directory
  so we don't have to go through the flow on each run

* Add code based on kubeflow/community#288 for using a service account (need
  to verify this actually works)

* Support the case where no video link or frequency is provided

Related to kubeflow/community#274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/298)
<!-- Reviewable:end -->
