### PR TITLE
Fix the calendar community events

### DIFF
--- a/calendar.yaml
+++ b/calendar.yaml
@@ -16,7 +16,7 @@
 - id: kf001
   name: Kubeflow Community Call
   date: 08/13/2019
-  time: 8:00AM-8:55AM
+  time: 5:30PM-6:25PM
   frequency: bi-weekly
   video: https://zoom.us/j/799749911
   description:
@@ -32,7 +32,7 @@
 - id: kf002
   name: Kubeflow Community Call
   date: 08/20/2019
-  time: 5:30PM-6:25PM
+  time: 8:00AM-8:55AM
   frequency: bi-weekly
   video: https://zoom.us/j/799749911
   description:


### PR DESCRIPTION
* The weekly community meetings in the YAML spec were out of sync with
  the actual schedule; the 08/13 and 08/20 meetings which were the first
  ones had the wrong time slots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/community/303)
<!-- Reviewable:end -->
