### PR TITLE
Updated label owners and info about shared drive

### DIFF
--- a/how-to/sharing_docs.md
+++ b/how-to/sharing_docs.md
@@ -18,5 +18,3 @@ You should be a member of the [kubeflow-discuss](https://groups.google.com/forum
 - [@chensun](http://github.com/chensun)
 - [@jessiezcc](http://github.com/jessiezcc)
 - [@kweinmeister](http://github.com/kweinmeister)
-- [@sarahmaddox](http://github.com/sarahmaddox)
-

--- a/labels-owners.yaml
+++ b/labels-owners.yaml
@@ -16,7 +16,8 @@ labels:
       - prodonjs
   area/docs:
     owners:
-      - sarahmaddox
+      - jlewi
+      - joeliedtke
   area/example:
     owners:
       - dansanche


### PR DESCRIPTION
Remove myself from the list of label owners and from the list of people to contact about the shared drive, as I'll be focusing on internal projects for a while. This update helps other contributors know that I won't be actively contributing to Kubeflow.