### PR TITLE
Fix YAML syntax areas in labels-owners file.

### DIFF
--- a/labels-owners.yaml
+++ b/labels-owners.yaml
@@ -12,6 +12,7 @@ labels:
     owners:
       - kkasravi
   area/auth:
+    owners:
       - yanniszark
   area/centraldashboard:
     owners:
@@ -53,6 +54,7 @@ labels:
       - kimwnasptd
       - vkoukis
   area/katib:
+    owners:
       - andreyvelich
       - gaocegege
       - hougangliu
@@ -73,6 +75,7 @@ labels:
       - jlewi
       - kunmingg
   area/multiuser:
+    owners:
       - yanniszark
   area/mxnet:
     owners:


### PR DESCRIPTION
* The list of owners should be in field OWNERs in the area label.