### PR TITLE
Temporarily disable KFP community meeting invite

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -292,3 +292,32 @@
 
   organizer: karlshriek
   
+- id: kf025
+  name: Kubeflow Pipelines Community Meeting (PST PM)
+  date: 08/05/2021
+  time: 5:30pm-6:10pm
+  frequency: monthly
+  video: https://meet.google.com/phd-ixfj-kcr
+  attendees:
+    - email: jamesjwu@google.com
+    - email: yangpa@google.com
+  description:
+    - |
+      Notes & Agenda: http://bit.ly/kfp-meeting-notes
+      Join at: https://meet.google.com/phd-ixfj-kcr
+  organizer: james-jwu
+
+- id: kf026
+  name: Kubeflow Pipelines Community Meeting (PST AM)
+  date: 08/19/2021
+  time: 10:00am-10:40am
+  frequency: monthly
+  video: https://meet.google.com/phd-ixfj-kcr
+  attendees:
+    - email: jamesjwu@google.com
+    - email: yangpa@google.com
+  description:
+    - |
+      Notes & Agenda: http://bit.ly/kfp-meeting-notes
+      Join at: https://meet.google.com/phd-ixfj-kcr
+  organizer: james-jwu


### PR DESCRIPTION
- Corrected the starting time of the PM meeting from 5:30am to 5:30pm
- Moved starting dates to year 2021. This is so that we can figure out why 'monthly' scheduled the meeting as a weekly event.
- Reduced the attendee to just myself and Yang. In case something goes wrong, the impact is just limited to 2 people.