### PR TITLE
fix(calendar): fixed Kubeflow community call (US East/EMEA)

### DIFF
--- a/calendar/README.md
+++ b/calendar/README.md
@@ -20,6 +20,12 @@ To add new meeting to the Kubeflow calendar follow these steps:
 
 1. You need to be calendar admin in kubeflow.org.
 
+1. You need to join the [kubeflow-discuss google group](https://groups.google.com/g/kubeflow-discuss), because
+
+    > Tip: If you have "View members" access to a group and create a group event, each member receives an invitation email. If you do not have  “View members” access, the group receives an invitation. Each user must accept the invite for the event to display appear on their calendar.
+
+    Note if you are using a user@kubeflow.org email account, you should join kubeflow-discuss with this account.
+
 1. You need a Google Cloud project (not sure whether it must be in kubeflow.org).
 
 1. Go to https://console.cloud.google.com/apis/credentials, create an OAuth 2.0 Client ID choosing `Desktop app` type.

--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -36,7 +36,7 @@
       International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: theadactyl
 
-- id: kf002
+- id: kf029
   name: Kubeflow Community Call (US East/EMEA)
   date: 08/18/2020
   time: 8:00AM-8:55AM

--- a/scripts/calendar_import.py
+++ b/scripts/calendar_import.py
@@ -99,7 +99,8 @@ def update_meeting(service, meeting):
 
   try:
     event = service.events().insert(calendarId=CALENDAR_ID, body=event).execute()
-    logging.info("Event created: {}".format(event.get('htmlLink')))
+    logging.info("Craeted Event: {}".format(meeting['name'][:100]))
+    logging.info(event.get('htmlLink'))
   except googleapiclient.errors.HttpError as e:
     content = json.loads(e.content)
 
@@ -108,7 +109,8 @@ def update_meeting(service, meeting):
       # It already exists so issue an update instead
       event = service.events().update(calendarId=CALENDAR_ID, eventId=meeting['id'],
                                       body=event).execute()
-      logging.info("Event updated: {}".format(event.get('htmlLink')))
+      logging.info("Updated Event: {}".format(meeting['name'][:100]))
+      logging.info(event.get('htmlLink'))
     else:
       logging.error("Exception occurred trying to insert event:\n%s",
                     content)


### PR DESCRIPTION
/assign @james-jwu @jlewi 

I tried to find the existing Kubeflow community call (US East/EMEA), but the calendar event says "canceled or deleted" when I open the web url.

The easiest fix I figured out is to use a new event id so that a new event is created.
I've tried multiple approaches to restore the old event, but it doesn't exist in event trash. I guess it's been deleted for too long.

I've already run the scripts, so the new event is already showing up in calendars.