### PR TITLE
Automatically sync the calendar

### DIFF
--- a/calendar/Dockerfile
+++ b/calendar/Dockerfile
@@ -1,0 +1,16 @@
+FROM google/cloud-sdk
+
+RUN apt-get update -y && \
+    apt-get install -y python3-distutils
+
+RUN python3.7 -m pip install \
+	fire==0.3.1 \
+	google-api-python-client==1.12.4 \
+	google-auth-oauthlib==0.4.1 \
+	oauth2client==4.1.3 \	
+	python-dateutil==2.8.1 \
+	pyyaml==5.3.1 \
+	six==1.15.0
+
+RUN mkdir -p /opt/kubeflow
+COPY calendar_import.py /opt/kubeflow

--- a/calendar/Makefile
+++ b/calendar/Makefile
@@ -1,0 +1,30 @@
+GIT_VERSION:=$(shell git describe --dirty --always)
+
+PROJECT:=kf-infra-gitops
+
+IMAGE:=gcr.io/$(PROJECT)/calendar-sync:$(GIT_VERSION)
+
+# Echo commands
+SHELL = sh -xv
+
+LATESTIMAGES=latest_image.yaml
+
+build-submit:
+	gcloud --project=$(PROJECT) builds submit --tag=$(IMAGE) ./
+
+build-output:
+	yq w -i latest_image.yaml $(PROJECT).calendar.image \
+	  $(IMAGE)@$(shell gcloud container images describe $(IMAGE) | yq r - image_summary.digest)
+
+set-image:
+	cd  manifests && kustomize edit set image calendar=$(shell yq r $(LATESTIMAGES) $(PROJECT).calendar.image)
+
+update-image: build-submit build-output set-image
+
+
+deploy:
+	kustomize build manifests | kubectl --context=$(CONTEXT) apply -f -
+
+# Build the image using GCB
+# We can't use skaffold due to: https://github.com/GoogleContainerTools/skaffold/issues/3468
+build: build-submit build-output

--- a/calendar/README.md
+++ b/calendar/README.md
@@ -16,6 +16,31 @@ To add new meeting to the Kubeflow calendar follow these steps:
 
 1. Then you should be able to see your new meeting in the calendar.
 
+## Automating calendar_import.py
+
+`calendar_import.py` is designed to run automatically using a robot account. 
+
+* We deploy it on Kubernetes
+* We run [git-sync](https://github.com/kubernetes/git-sync) in a side car to synchronize the repo to a volume mount
+* When calendar_import.py detects a change it runs the sync
+
+### Where it Runs
+
+* Project: kf-infra-gitops
+
+* Project configs [kubeflow/community-infra/tree/master/prod/namespaces/kf-infra-gitops](https://github.com/kubeflow/community-infra/tree/master/prod/namespaces/kf-infra-gitops)
+
+
+### Using a Google Service Account with the Calendar API
+
+* We need to enable [Domain Delegation](https://developers.google.com/identity/protocols/oauth2/service-account)
+  for the service account
+
+  * Without this the GSA can add events to the calendar but not invite attendees to the meeting
+  * Domain wide configuration is restricted to the calendar scope to minimize the damage this can do
+
+* In order to use domain wide configuration the GSA needs to impersonate a user; we have created the account "autobot.kubeflow.org" for this
+
 ## Before running `calendar_import.py`
 
 1. You need to be calendar admin in kubeflow.org.

--- a/calendar/latest_image.yaml
+++ b/calendar/latest_image.yaml
@@ -1,0 +1,4 @@
+image: hello
+kf-infra-gitops:
+  calendar:
+    image: gcr.io/kf-infra-gitops/calendar-sync:c0ec5d7-dirty@sha256:a0669afe42c156609d0e2d152c40d6cd68eec7de4ef35a2153cd21e076de4589

--- a/calendar/manifests/deployment.yaml
+++ b/calendar/manifests/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calendar-sync
+  labels:
+    app: calendar-sync
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: calendar-sync
+  template:
+    metadata:
+      labels:
+        app: calendar-sync
+    spec:
+      containers:
+      - name: calendar-sync
+        image: calendar
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secrets/gsa.json
+        command:
+          - python3.7
+          - /opt/kubeflow/calendar_import.py
+          - periodic-sync
+          - --config=/data/community.git/calendar/calendar.yaml
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: gsa
+          mountPath: "/secrets"
+          readOnly: true
+      - name: sync
+        image: k8s.gcr.io/git-sync:v3.1.6
+        args:
+        - --repo=https://github.com/kubeflow/community.git
+        - --branch=master
+        - --root=/data
+        # In seconds
+        - --wait=30
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: gsa
+          secret:
+            secretName: calendar-gsa

--- a/calendar/manifests/kustomization.yaml
+++ b/calendar/manifests/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: calendar-sync
+resources:
+- deployment.yaml
+images:
+- digest: sha256:a0669afe42c156609d0e2d152c40d6cd68eec7de4ef35a2153cd21e076de4589
+  name: calendar
+  newName: gcr.io/kf-infra-gitops/calendar-sync:c0ec5d7-dirty


### PR DESCRIPTION
* Update the code to work with service accounts

  * We need to use domain delegation when using a service account otherwise
    we get an error when trying to add attendees

  * With a service account there's no need to pickle credentials and there's
    no need to specify an oauth client as each GSA has an implicit oauth client.

* Add an option to run continuously

  * Continuously check if there are changes to the file and if there are
    run the calendar sync.

* Create a Makefile to build the image
* Create a Kubernetes deployment which runs git-sync in a sidecar.
Related to #274