### PR TITLE
calendar_import.py should use OAuth credentials for autobot@kubeflow.org

### DIFF
--- a/calendar/Dockerfile
+++ b/calendar/Dockerfile
@@ -7,6 +7,7 @@ RUN python3.7 -m pip install \
 	fire==0.3.1 \
 	google-api-python-client==1.12.4 \
 	google-auth-oauthlib==0.4.1 \
+	google-cloud-secret-manager==2.0.0 \
 	oauth2client==4.1.3 \	
 	python-dateutil==2.8.1 \
 	pyyaml==5.3.1 \

--- a/calendar/Makefile
+++ b/calendar/Makefile
@@ -9,8 +9,10 @@ SHELL = sh -xv
 
 LATESTIMAGES=latest_image.yaml
 
+CONTEXT:=kf-autobot
+
 build-submit:
-	gcloud --project=$(PROJECT) builds submit --tag=$(IMAGE) ./
+	gcloud --project=$(PROJECT) builds submit --machine-type=n1-highcpu-32 --tag=$(IMAGE) ./
 
 build-output:
 	yq w -i latest_image.yaml $(PROJECT).calendar.image \

--- a/calendar/README.md
+++ b/calendar/README.md
@@ -27,6 +27,8 @@ To add new meeting to the Kubeflow calendar follow these steps:
 ### Where it Runs
 
 * Project: kf-infra-gitops
+* Cluster: kf-org-admin
+* Namespace: kf-autobot
 
 * Project configs [kubeflow/community-infra/tree/master/prod/namespaces/kf-infra-gitops](https://github.com/kubeflow/community-infra/tree/master/prod/namespaces/kf-infra-gitops)
 

--- a/calendar/calendar_import.py
+++ b/calendar/calendar_import.py
@@ -7,6 +7,9 @@ Requires the following packages: oauth2client, pyyaml, google-api-python-client
 
 Uses a service account -- the calendar must be shared with the service account
 email and given permission: "Make changes to events"
+  * Using a service account requires domain wide delegation in order to
+    add attendees to meetings
+
 
 References:
   https://developers.google.com/calendar/quickstart/python
@@ -22,8 +25,11 @@ import subprocess
 import time
 import yaml
 import googleapiclient.errors
+from google.oauth2 import credentials
+from google.api_core import exceptions as google_exceptions
 from googleapiclient.discovery import build
 from google_auth_oauthlib import flow
+from google.cloud import secretmanager
 from google.auth.transport import requests
 from oauth2client import service_account
 from pathlib import Path
@@ -35,11 +41,10 @@ CALENDAR_ID = 'kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com
 
 SCOPES = ['https://www.googleapis.com/auth/calendar.events']
 
-# This is owned project kf-infra-gitops
-# It is the unique id of the service account.
-# TODO(jlewi): Do we need to set it when using a service account or does
-# it get filled in automatically from the service account key?
-#DEFAULT_OAUTH_CLIENT_ID = "105316821451047170130"
+# The default GCP project and name of a secret in secret manager
+# containing the oauth credentials for autobot@kubeflow.org.
+DEFAULT_PROJECT = "kf-infra-gitops"
+DEFAULT_SECRET = "autobot-at-kubeflow-oauth"
 
 def update_meeting(service, meeting):
   date = meeting['date']
@@ -125,12 +130,17 @@ def update_meeting(service, meeting):
   except Exception as e:
     logging.error("Error occurred creating the event: ", e)
 
-def get_user_credentials(oauth_client_secret=None):
+def get_user_credentials(oauth_client_secret=None,
+                         credentials_file=None):
   """Obtain user credentials through the web flow.
 
   oauth_client_secret: Path to the json file containing an OAuth client id
         for an OAuth application to use the Calendar API. Only required if
         not using a service account
+
+  credentials_file: Where to save the credentials
+
+  credentials_secret:
   """
   home = str(Path.home())
   config_dir = os.path.join(home, ".config", "kubeflow", "calendar_import")
@@ -139,30 +149,33 @@ def get_user_credentials(oauth_client_secret=None):
 
   # File to store credentials
   # Only used with the personal login flow.
-  credentials_file = os.path.join(config_dir, "token.pickle")
+  if not credentials_file:
+    credentials_file = os.path.join(config_dir, "credentials.json")
 
   # TODO(jlewi): Don't hardcode this
   if not oauth_client_secret:
     raise ValueError("An oauth_client_secret is required when using end user "
                      "credentials")
+  creds = None
+
   # The file token.pickle stores the user's access and refresh tokens, and is
   # created automatically when the authorization flow completes for the first
   # time.
   if os.path.exists(credentials_file):
-    with open(credentials_file, 'rb') as token:
-      creds = pickle.load(token)
-  # If there are no (valid) credentials available, let the user log in.
-  if not creds or not creds.valid:
-    if creds and creds.expired and creds.refresh_token:
-      creds.refresh(requests.Request())
-    else:
-      web_flow = flow.InstalledAppFlow.from_client_secrets_file(oauth_client_secret,
-                                                                SCOPES)
-      creds = web_flow.run_local_server(port=0)
+    creds = credentials.Credentials.from_authorized_user_file(credentials_file)
 
-      # Save the credentials for the next run
-      with open(credentials_file, 'wb') as token:
-        pickle.dump(creds, token)
+  # If there are no (valid) credentials available, let the user log in.
+  if not creds:
+    web_flow = flow.InstalledAppFlow.from_client_secrets_file(oauth_client_secret,
+                                                              SCOPES)
+    creds = web_flow.run_local_server(port=0)
+
+    # Save the credentials for the next run
+    with open(credentials_file, 'w') as token:
+      token.write(creds.to_json())
+
+  if creds.expired and creds.refresh_token:
+    creds.refresh(requests.Request())
 
   return creds
 
@@ -171,6 +184,64 @@ def _get_default_config():
   repo_root = os.path.abspath(os.path.join(os.path.dirname(this_file), ".."))
   config = os.path.join(repo_root, "calendar/calendar.yaml")
   return config
+
+def create_secret(client, project, secret):
+  """
+  Create a new secret with the given name. A secret is a logical wrapper
+  around a collection of secret versions. Secret versions hold the actual
+  secret material.
+  """
+
+
+  # Build the resource name of the parent project.
+  parent = f"projects/{project}"
+
+  # Create the secret.
+  try:
+    response = client.create_secret(
+        request={
+            "parent": parent,
+              "secret_id": secret,
+              "secret": {"replication": {"automatic": {}}},
+          }
+      )
+  except google_exceptions.AlreadyExists:
+    logging.info("Secret already exists")
+    return
+
+  # Print the new secret name.
+  logging.info("Created secret: {response.name}")
+
+def load_secret(client, project, secret):
+  path = client.secret_path(project, secret)
+
+  name = f"{path}/versions/latest"
+  logging.info(f"Fetching secret {name}")
+  # Access the secret version.
+  response = client.access_secret_version(request={"name": name})
+
+  # Print the secret payload.
+  #
+  # WARNING: Do not print the secret in a production environment - this
+  # snippet is showing how to access the secret material.
+  payload = response.payload.data.decode("UTF-8")
+  return payload
+
+def sync_calendar(config, creds):
+  service = build('calendar', 'v3', credentials=creds)
+
+  logging.info("Loading calendar data from %s", config)
+  with open(config) as cal:
+    meetings = yaml.safe_load(cal)
+
+    for meeting in meetings:
+      try:
+        update_meeting(service, meeting)
+      except Exception as e:
+        logging.error("Could not update meeting %s; Error:\n%s",
+                      meeting.get("id"), e)
+        continue
+
 
 class CalendarUpdater:
   """Class to update the calendar"""
@@ -210,27 +281,20 @@ class CalendarUpdater:
     else:
       creds = get_user_credentials(oauth_client_secret=oauth_client_secret)
 
-    service = build('calendar', 'v3', credentials=creds)
-
-    logging.info("Loading calendar data from %s", config)
-    with open(config) as cal:
-      meetings = yaml.safe_load(cal)
-
-      for meeting in meetings:
-        try:
-          update_meeting(service, meeting)
-        except Exception as e:
-          logging.error("Could not update meeting %s; Error:\n%s",
-                        meeting.get("id"), e)
-          continue
+    sync_calendar(config, creds)
 
   @staticmethod
-  def periodic_sync(config=None, period_seconds=15):
+  def periodic_sync(config=None, project=DEFAULT_PROJECT,
+                    secret=DEFAULT_SECRET, period_seconds=15):
     """Run the sync periodically at the desired interval.
 
     The sync only runs when the commit changes
 
     Args:
+      config: Path to the YAML file containing the calendar config
+      project: The GCP project containing the secret containing OAuth
+        credentials for the bot account to run as
+      secret: The name of the secret in GCP secret manager
       period_seconds: How frequently to check for changes to the file.
         This should be pretty frequent since the sync only runs when changes
         are detected.
@@ -243,6 +307,12 @@ class CalendarUpdater:
 
     logging.info("Config: %s", config)
     git_dir = os.path.dirname(config)
+
+    client = secretmanager.SecretManagerServiceClient()
+
+    secret_contents = load_secret(client, project, secret)
+    creds_json = json.loads(secret_contents)
+    creds = credentials.Credentials.from_authorized_user_info(creds_json)
 
     while True:
       # This is a bit of a hack. When relying on a side car (e.g. git-sync)
@@ -261,12 +331,57 @@ class CalendarUpdater:
 
       if latest != last_tag:
         logging.info("Running sync")
-        CalendarUpdater.sync(config=config)
+        sync_calendar(config, creds)
       else:
         logging.info("No changes; not syncing")
 
       last_tag = latest
       time.sleep(period_seconds)
+
+  @staticmethod
+  def mint_credentials(project, secret, oauth_client_secret):
+    """Mint credentials for a particular user:
+
+    The purpose of this command is to persist OAuth credentials for a
+    desktop app to a file:
+    https://developers.google.com/identity/protocols/oauth2/native-app
+
+    The purpose of this is to allow impersonating a bot account for
+    the purpose of automation.
+
+    Args:
+      project: GCP project to store the secret in
+      secret: The id of a secret in GCP secret manager to save the secret
+        to.
+      oauth_client_secret: Path to the json file containing an OAuth client id
+        for an OAuth application to use the Calendar API. Only required if
+        not using a service account
+    """
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    create_secret(client, project, secret)
+
+    # Build the resource name of the parent secret.
+    parent = client.secret_path(project, secret)
+
+    # Go through the webflow
+    web_flow = flow.InstalledAppFlow.from_client_secrets_file(oauth_client_secret,
+                                                                SCOPES)
+    creds = web_flow.run_local_server(port=0)
+
+    # Convert the string payload into a bytes. This step can be omitted if you
+    # pass in bytes instead of a str for the payload argument.
+    payload = creds.to_json().encode("UTF-8")
+
+    # Add the secret version.
+    response = client.add_secret_version(
+        request={"parent": parent, "payload": {"data": payload}}
+      )
+
+    # Print the new secret version name.
+    logging.info("Added secret version: {}".format(response.name))
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.INFO,

--- a/calendar/latest_image.yaml
+++ b/calendar/latest_image.yaml
@@ -1,4 +1,4 @@
 image: hello
 kf-infra-gitops:
   calendar:
-    image: gcr.io/kf-infra-gitops/calendar-sync:c0ec5d7-dirty@sha256:a0669afe42c156609d0e2d152c40d6cd68eec7de4ef35a2153cd21e076de4589
+    image: gcr.io/kf-infra-gitops/calendar-sync:9c5e87b-dirty@sha256:5f169ff3ad1e66d96643a68f330e78bcc78a5c4752b5f85de343220a60425dc2

--- a/calendar/manifests/deployment.yaml
+++ b/calendar/manifests/deployment.yaml
@@ -17,9 +17,6 @@ spec:
       containers:
       - name: calendar-sync
         image: calendar
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /secrets/gsa.json
         command:
           - python3.7
           - /opt/kubeflow/calendar_import.py
@@ -28,9 +25,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
-        - name: gsa
-          mountPath: "/secrets"
-          readOnly: true
       - name: sync
         image: k8s.gcr.io/git-sync:v3.1.6
         args:
@@ -42,9 +36,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+      serviceAccount: kf-autobot
       volumes:
         - name: data
           emptyDir: {}
-        - name: gsa
-          secret:
-            secretName: calendar-gsa

--- a/calendar/manifests/kustomization.yaml
+++ b/calendar/manifests/kustomization.yaml
@@ -1,9 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: calendar-sync
+namespace: kf-autobot
 resources:
 - deployment.yaml
+- service-account.yaml
 images:
-- digest: sha256:a0669afe42c156609d0e2d152c40d6cd68eec7de4ef35a2153cd21e076de4589
+- digest: sha256:5f169ff3ad1e66d96643a68f330e78bcc78a5c4752b5f85de343220a60425dc2
   name: calendar
-  newName: gcr.io/kf-infra-gitops/calendar-sync:c0ec5d7-dirty
+  newName: gcr.io/kf-infra-gitops/calendar-sync:9c5e87b-dirty

--- a/calendar/manifests/service-account.yaml
+++ b/calendar/manifests/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:    
+    iam.gke.io/gcp-service-account: kf-autobot@kf-infra-gitops.iam.gserviceaccount.com  
+  name: kf-autobot


### PR DESCRIPTION
* We don't want to use a google service account because that requires
  domain wide delegation.

* Instead we change the script to impersonate autobot@kubeflow.org

  * We do this by generating a refresh credential for autobot@kubeflow.org
    and saving it as a GCP secret. A human needs to do this as the human
    needs to go through the OAuth Web Flow

* When running the sync we read the OAuth credential from the GCP secret
  and impersonate autobot@kubeflow.org

* We use a GSA and workload identity to access secret manager.

* Move to the kf-autobot namespace.

Fix: #274 