### PR TITLE
Add a slack channel for wg-notebooks

### DIFF
--- a/slack/slack_channels.md
+++ b/slack/slack_channels.md
@@ -76,5 +76,6 @@
 *  triage
 *  website - Work on the Kubeflow docs
 *  wg-automl - AutoML Working Group discussion
+*  wg-notebooks - Notebooks Working Group discussion
 *  wg-training - Training Working Group discussion
 *  xgboost-operator


### PR DESCRIPTION
We need to have a slack channel for Notebooks to discuss the state of this WG.

/cc @mameshini 
/assign @kimwnasptd 

cc @kubeflow/wg-notebook-leads 