### PR TITLE
Change AutoML meeting ID

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -342,11 +342,12 @@
       Join at: https://meet.google.com/jkr-dupp-wwm
   organizer: james-jwu
 
-- id: kf027
+- id: kf032
   name: Kubeflow AutoML Working Group Meeting (Asia & Europe friendly)
   date: 09/09/2020
   time: 3:00am-4:00am
   frequency: monthly
+  until: 09/09/2022
   video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
@@ -357,13 +358,14 @@
       Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
       Meeting ID: 839 443 5453
       Passcode: R3ScM7
-  organizer: andreyvelich
+  organizer: autobot@kubeflow.org
 
-- id: kf028
+- id: kf033
   name: Kubeflow AutoML Working Group Meeting (US friendly)
   date: 09/23/2020
   time: 9:00am-10:00am
   frequency: monthly
+  until: 09/09/2022
   video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
@@ -374,7 +376,7 @@
       Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
       Meeting ID: 839 443 5453
       Passcode: R3ScM7
-  organizer: andreyvelich
+  organizer: autobot@kubeflow.org
   
 - id: kf029
   name: Kubeflow Feature Store SIG Meeting (US/Asia friendly)


### PR DESCRIPTION
Related: https://github.com/kubeflow/community/issues/438#issuecomment-721337700.
I changed AutoML meetings ID, organizer and add until date.
We need to delete old events: kf027 and kf028.

/assign @Bobgy 
/cc @jlewi @karlschriek 