### PR TITLE
Remove AutoML meetings from the Kubeflow calendar

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -316,42 +316,6 @@
       Join at: https://meet.google.com/jkr-dupp-wwm
   organizer: james-jwu
 
-- id: kf032
-  name: Kubeflow AutoML Working Group Meeting (Asia & Europe friendly)
-  date: 09/09/2020
-  time: 3:00am-4:00am
-  frequency: monthly
-  until: 09/09/2022
-  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://docs.google.com/document/d/1MChKfzrKAeFRtYqypFbMXL6ZIc_OgijjkvbqmwRV-64
-
-      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-      Meeting ID: 839 443 5453
-      Passcode: R3ScM7
-  organizer: autobot@kubeflow.org
-
-- id: kf033
-  name: Kubeflow AutoML Working Group Meeting (US friendly)
-  date: 09/23/2020
-  time: 9:00am-10:00am
-  frequency: monthly
-  until: 09/09/2022
-  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://docs.google.com/document/d/1MChKfzrKAeFRtYqypFbMXL6ZIc_OgijjkvbqmwRV-64
-
-      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-      Meeting ID: 839 443 5453
-      Passcode: R3ScM7
-  organizer: autobot@kubeflow.org
-  
 - id: kf029
   name: Kubeflow Feature Store SIG Meeting (US/Asia friendly)
   date: 11/25/2020


### PR DESCRIPTION
I removed AutoML meetings, since we are migrating to our own calendar from the Kubeflow calendar.
Related to: https://github.com/kubeflow/community/issues/445.

I will update the WGs yaml in the following PRs.

New calendar link: https://calendar.google.com/calendar/u/0/r?cid=ZDQ5bnNpZWZzbmZna2Y5MW8wdThoMmpoazRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ. 

/assign @Bobgy @johnugeorge @gaocegege
/cc @jlewi 