### PR TITLE
Increment meeting number to force new invites

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -37,7 +37,7 @@
       International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: theadactyl
 
-- id: kf031
+- id: kf032
   name: Kubeflow Community Call (US East/EMEA)
   date: 08/18/2020
   time: 8:00AM-8:55AM


### PR DESCRIPTION
The community meeting dropped off of a bunch of people's calendar's today. Mathew Wicks thinks that incrementing this number will force it to delete and recreate the meeting via kubeflow-discuss. So I figure it's worth a shot. 

