### PR TITLE
[WIP] Initial blog guidelines

### DIFF
--- a/guidelines/blog-guidelines.md
+++ b/guidelines/blog-guidelines.md
@@ -1,6 +1,6 @@
 # Kubeflow Blog Guidelines
 
-The Knative blog is owned by $group and run by the $other_group. 
+The Kubeflow blog is owned by $group and run by the $other_group. 
 
 This section covers documentation, processes, and roles for the [Kubeflow blog](https://blog.kubeflow.org/).
 

--- a/guidelines/blog-guidelines.md
+++ b/guidelines/blog-guidelines.md
@@ -1,0 +1,57 @@
+# Kubeflow Blog Guidelines
+
+The Knative blog is owned by $group and run by the $other_group. 
+
+This section covers documentation, processes, and roles for the [Kubeflow blog](https://blog.kubeflow.org/).
+
+## Leadership
+
+- **Technical Editors:**
+- **Copy Editors:** 
+- **Blog Community Managers:**
+
+## Contact
+
+- Slack: [#blog]
+
+### Blog Guidelines
+
+#### Suitable content:
+
+- **Original content only**
+- Kubeflow project release information
+- Topics related to participation in or results of working group activities
+- Tutorials and demos
+- Use cases
+- Content that is specific to a vendor or platform about Kubeflow installation and use
+
+#### Unsuitable Content:
+- Content that does not address Kubeflow in any way
+- Content that doesn't interact with Kubeflow APIs, interfaces, or other technology owned by Kubeflow Working Groups
+- Vendor pitches
+  - Submissions must contain content that applies broadly to the Kubeflow Community, for example a submission should focus on upstream Kubeflow as opposed to vendor-specific configurations.
+  - Links should primarily be to the official Kubeflow documentation and other project properties. When using external references, links should be diverse.
+
+## Review Process
+
+After a blog post is submitted as a PR, it is automatically assigned to a reviewer.
+
+Each blog post requires a `lgtm` label from at least one person in the editorial team.
+Once the necessary labels are in place, one of the reviewers will add an `approved` label, and schedule publication of the blog post.
+
+### Service level agreement (SLA)
+
+Blog posts can take up to **1 week** to review.
+If you'd like to request an expedited review, please say so on your message when you ping the editorial team on Slack.
+
+## Submit a Post
+
+Anyone can write a blog post and submit it for review. 
+Commercial content is not allowed.
+Please refer to the guidelines at the top of this document for more guidance.
+
+To submit a blog post, follow the steps below.
+
+### Technical Considerations for submitting a blog post
+
+Once you have determined that you would like to submit a blog post follow the [Kubeflow Website Documentation](https://github.com/kubeflow/website/).


### PR DESCRIPTION
Here's a first stab at blog guidelines, please do not consider merging at this time as this is draft and needs discussion. It is an amalgamation of the K8s and Knative blog guidelines. 

Notes to our future selves: 
- The [twitter guidelines](https://github.com/kubeflow/community/issues/487) are also in flight and this will need to sync with that. 
- The website repo has it's own technical instructions for submitting posts so I linked to those instead of replicating them here.
- As the community guidelines get concensus, we might want to consider combining the blog and twitter guidelines into one document that is guidelines content only, and then refer the technical instructions to whichever place those end up being. This would avoid duplication of rules across multiple documents. Howerver one document per property isn't a bad place to start. 