### PR TITLE
PatrickXYS@ step down

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,13 +11,11 @@ aliases:
     - gaocegege
     - johnugeorge
   wg-deployment-leads:
-    - PatrickXYS
     - animeshsingh
     - mameshini
     - vpavlin
     - yanniszark
   wg-manifests-leads:
-    - PatrickXYS
     - StefanoFioravanzo
     - elikatsis
     - kimwnasptd

--- a/wgs.yaml
+++ b/wgs.yaml
@@ -141,9 +141,6 @@ workinggroups:
   label: area/wg-deployment
   leadership:
     chairs:
-    - github: PatrickXYS
-      name: Yao Xiao
-      company: AWS
     - github: animeshsingh
       name: Animesh Singh
       company: IBM
@@ -157,9 +154,6 @@ workinggroups:
       name: Yannis Zarkadas
       company: Arrikto
     tech_leads:
-    - github: PatrickXYS
-      name: Yao Xiao
-      company: AWS
     - github: animeshsingh
       name: Animesh Singh
       company: IBM
@@ -202,9 +196,6 @@ workinggroups:
   label: area/wg-manifests
   leadership:
     chairs:
-    - github: PatrickXYS
-      name: Yao Xiao
-      company: AWS
     - github: kimwnasptd
       name: Kimonas Sotirchos
       company: Arrikto
@@ -212,9 +203,6 @@ workinggroups:
       name: Yannis Zarkadas
       company: Arrikto
     tech_leads:
-    - github: PatrickXYS
-      name: Yao Xiao
-      company: AWS
     - github: StefanoFioravanzo
       name: Stefano Fioravanzo
       company: Arrikto


### PR DESCRIPTION
Since recently I left AWS and joined Google, I won't be working on the kubeflow manifests and deployment areas. 

I made the change to remove myself from co-leader of WG-manifests and WG-deployment.

It's been a great journey working with all of kubeflow community folks!

/cc @kubeflow/wg-manifests-leads  @kubeflow/wg-deployment-leads @kubeflow/wg-notebooks-leads  @kubeflow/wg-serving-leads  @kubeflow/wg-training-leads @kubeflow/wg-automl-leads @kubeflow/wg-pipeline-leads 