### PR TITLE
Add release related documentation (#531)

### DIFF
--- a/releases/OWNERS
+++ b/releases/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - annajung
+  - jbottum
+  - kimwnasptd
+  - shannonbradshaw
+reviewers:
+  - annajung
+  - jbottum
+  - kimwnasptd
+  - shannonbradshaw

--- a/releases/README.md
+++ b/releases/README.md
@@ -1,0 +1,14 @@
+# Kubeflow Release
+
+### Release Team Meetings
+- [Monday 09:00 PST / 17:00 UTC](https://arrik.to/kf-release-team-meet)
+  - [Meeting Agenda and Notes](https://arrik.to/kf-release-team-notes) 
+- [Calendar Invite](https://arrik.to/kf-release-team-cal)
+
+### Resources
+- [Release Handbook](./handbook.md)
+- [Meeting Recordings](https://arrik.to/kf-release-team-recordings)
+
+### Contact
+- Slack [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) channel
+- GitHub Teams [@release-team](https://github.com/orgs/kubeflow/teams/release-team)

--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -1,0 +1,342 @@
+# Kubeflow Release Handbook
+
+## Executive Summary
+
+The purpose of this document is to define the roles and processes for the Kubeflow community to release Kubeflow. This document will attempt to coordinate releasing between the five major components and working groups in Kubeflow, as well as defining best practices, roles, and processes to make releasing Kubeflow easier for the community with each iteration.
+
+## People and Roles
+
+### Release Manager
+The Release Manager will be responsible for coordinating the release and taking ultimate accountability for all release tasks to be completed on time.
+
+If multiple Release Team members meet the prerequisites to become a Release Manager, the one from a different organization than the one that drove the previous release should be preferred.
+
+**Prerequisites:**
+1. Be a contributor for at least 1 year
+2. Have shadowed in a previous release or be a Release Team member in the past
+3. Contributions in at least 2 Working Groups
+
+**Time Commitments:** This role will need to be synchronous. The Release Manager is expected to be joining all the weekly and burndown meetings as well as coordinate with the Release Team and the Working Group leads. For the Development phase an estimate of the work needed is 4-8 hours per week. For the next phases the Release Manager will need to devote more time and coordinate the tasks of the release.
+
+**Responsibilities:**
+* Providing updates to the mailing list with the progress of the release
+* Coordinating directly with the WG liaisons and leads about dates and deliverables
+* Coordinating with the Release Team Members for the progress of the release
+* Ensuring the WG leads have cut the necessary github branches and tags for the different phases of the release
+* Driving the Release Team meetings
+* Making sure the processes are being followed
+* All the responsibilities of a Release Team Member
+
+**Autority:**
+The Release Manager will need to have authority to take some decisions, in
+order to ensure the stability of the release and completion in a timely manner.
+Such decisions include:
+* Moving the release process to the next phase, even if there are controversial issues at hand
+* Delaying the release until some important issues are resolved
+* Denying component version upgrades
+
+### Release Team Member
+Release Team Members ensure that there's enough bandwidth to perform release related tasks. They work closely with the Release Manager to address release issues.
+
+**Prerequisites:** none
+
+**Time Commitments:** Their role will need to be synchronous, since they are expected to join the Release meetings. Their time commitment is expected to be spread out throughout the release.
+
+**Responsibilities:**
+
+* Keeping track of the provided component versions and updating the [versions table](https://github.com/kubeflow/manifests#kubeflow-components-versions)
+* Creating PRs to update manifests repo from WG provided git revisions
+* Attending the Release Team meetings
+* Providing feedback on enhancing the current Release Handbook
+* Keeping notes from the Release Team meetings, in a rotation manner between the members
+
+### Product Manager
+They will be in charge of driving non-code deliverables, like the post-release blog post and social media announcements.
+
+**Prerequisites:** Experience in writing blog posts. Contributions to an existing Open Source project is a huge plus.
+
+**Time Commitments:** This role will require some synchronous communication, since they will need to attend some of the later Release Team meetings. Most of the effort is expected to start once the Feature Freeze phase completes, where they will start working on the blog and release announcements.
+
+**Responsibilities:**
+
+* Driving the blog post effort
+* Handling communication for social media content publication
+* Orchestrating and creating user surveys
+* Tracking important features and bug fixes that should be highlighted in the release.
+
+### Docs Lead
+The Docs Lead is responsible for working with the Release Team to coordinate documentation updates for the next Kubeflow release.
+
+**Prerequisites:** Contributions to the [website repo](https://github.com/kubeflow/website)
+
+**Time Commitments:** This role will require some synchronous communication. The bulk of their work is expected to be in the Documentation phase of the release, but they will also be involved throughout the release by keeping track of issues that might require an update to the docs.
+
+**Responsibilities:**
+* Identifying and tracking new issues that require update to the docs
+* Working with contributors to modify existing docs to accurately represent any upcoming changes
+* Reviewing documentation PRs to ensure quality following the website [Style Guide](https://www.kubeflow.org/docs/about/style-guide/)
+* Migrating the old website [version] documentation and updating it with the new release
+
+### Working Group Liaison
+Person responsible for liaising between the release team and the WG. The will
+be the main contact point for the Release Team to figure out the progress of
+the WG as well as required component versions, throughout the release. If a
+Release Team Member is already part of a WG then they could also serve as the
+liaison.
+
+**Prerequisites:** Contributor in the Working Group and acknowledged from the tech leads of that Working Group
+
+**Time Commitments:** This role can be completely asynchronous. Most of their work is expected to be in the Feature Freeze and Documentation phases.
+
+**Responsibilities:**
+- Providing a roadmap and dependency updates to the Community early in the release cycle
+- Communicating with Release Team during the Feature Freeze about the progress of bug fixes
+
+### Distribution Representative
+
+**Prerequisites:** Work at the organization that owns the distribution
+
+**Time Commitments:** This role can be completely asynchronous. Most of their work is expected to be in the Distribution testing phase. Ideally they should be involved when the first RC is cut in order to alert early for potential issues.
+
+**Responsibilities:**
+- Exposing issues that the distribution owner is facing with the new release
+- Syncing with the release team during distro testing phase, we want a nice tight feedback loop there
+
+### Shadow
+
+A person that works closely with a specific release team member as an apprentice. The member they shadow will be acting as a mentor to the shadow and will be educating them about the tasks and day to day operations that specific role needs to perform.
+
+Any Release Team member may select one or more mentees to shadow the release process in order to help fulfill future Release Team staffing requirements and continue to grow the Kubeflow community in general.
+
+**Prerequisites:** none
+
+**Time Commitments:** The shadows should be prepared to invest a lot of cycles to be up to date with the work done from their mentor
+
+**Responsibilities:**
+- Staying in sync with the work done by their mentor
+- Keeping a list of things that could be improved in the next release for the role they shadow
+
+## Proposed WG Processes
+
+### Releasing
+
+We are moving to a release cadence of **4 months**, in response to our 3 month cycle being tight for the typical set of features we have wanted to release.The release is planned out with 10 weeks of development, with 6 weeks of feature freeze, documentation work, and other processes. At some point there will be a feature freeze, as described below, in the manifests repo. This means that other WGs cannot request the Manifest WG leads to update the repo to change a component’s YAML files, if the update sets a new image with new features.
+
+The above means that WGs, which will be maintaining a list of repos, will only be providing git revisions that only include bug fixes and not features, to the Manifests WG leads.
+
+We recommend adopting a release branch to cope with this form of releasing; we suggest that all WGs follow the process below for releasing new versions of their software:
+
+1. Create a new branch for your new version
+2. Use tags for the release that will be pointing to commits in the created branch
+
+This way a WG can keep on pushing new features to their **master** branch. Once there’s a feature freeze, in manifests repo, they can cherry-pick bug fixes to their new branch and request from the Manifests WG leads to sync the manifests from commits in that branch. This ensures that the newer commits will only include bug fixes.
+
+### Documentation
+
+Working groups should briefly describe what changes to existing [kubeflow.org](https://www.kubeflow.org/) documentation will be required to ensure the docs reflect new features or other software updates. A few bullets identifying which pages in the docs need to change will suffice. These bullets should be added to the Working Group’s GitHub issues describing planned engineering work.
+
+Working Groups should be tracking features for the release, as well as the documentation status of each feature as it’s being developed so that the documentation team can keep track of the documentation work that needs to be done.
+
+## Terminology
+
+### git revision
+
+A git revision is either a git commit, branch, or tag. Ideally people should be providing the manifests repo with tags, to update the manifests from.
+
+
+### Release Candidate (RC)
+
+The Release Candidate (RC) in the manifests repo is always a git **tag**.
+
+The manifests repo will be following the release process below:
+
+1. There will be a **vX.Y-branch** branch, in which the Manifests WG leads will be cherry picking commits on top
+2. Manifests leads will be creating new tags for different RCs, that will be pointing to commits of that release branch
+
+
+## Timeline
+
+| Week | Events |
+| --- | --- |
+| 1 | Development |
+| 2 |   |
+| 3 |   |
+| 4 |   |
+| 5 |   |
+| 6 |   |
+| 7 |   |
+| 8 |   |
+| 9 |   |
+| 10 |   |
+| 11 | Feature Freeze, Documentation |
+| 12 |   |
+| 13 | Manifests testing week |
+| 14 | Distributions testing |
+| 15 |   |
+| 16 |   |
+| 17 | Release |
+
+
+### Preparation
+
+- [ ] Select a release team
+- [ ] Working groups broadly think about features **with priorities** they want to land for that cycle, have internal discussions, perhaps groom a backlog from previous cycle, get issues triaged, etc.
+- [ ] Ensure members of the Release Team are part of the [release-team](https://github.com/kubeflow/internal-acls/blob/54a454b92e34a98f74a8dc07216dd578f6fa40d5/github-orgs/kubeflow/org.yaml#L950) group
+- [ ] Establish a regular release team meeting as appropriate on the schedule, start off slowly, but meet more often towards the end.
+- [ ] Publish draft schedule to kubeflow-discuss, with actual dates
+- [ ] Get lazy consensus on the release schedule from the WG leads
+- [ ] Ensure schedule also accounts for the patch releases AFTER the minor release
+- [ ] Reach out to each WG to determine WG Liaison for the release
+
+Criteria for timeline that the team needs to consider
+- Holidays around the world that coincide with members of the release team, WG representatives, and distro representatives.
+- Enterprise budgeting/approval lifecycle. (aka users have their own usage and purchase requirements and deadlines)
+- Kubecon dates - let’s not hard block on events, but keep them in mind since we know community members might get doublebooked.
+- Associated events (aka. AI Day at Kubecon, Tensorflow events) - we want to keep them in mind.
+
+**Success Criteria:** Release team selected, schedule sent to kubeflow-discuss, all release team members have the proper permissions and are meeting regularly.
+
+
+### Development (10 weeks)
+
+Normal development in the different WGs and in the <https://github.com/kubeflow/manifests> repo.
+
+**Success Criteria:**
+* (Optional but encouraged): Issues tracking new features should also provide information on whether the docs should be updated for that feature
+
+
+### Feature Freeze (2 weeks)
+
+From that phase and forward updates to the manifests repo must only be fixing component bugs. No new commits, in the manifests repo, that update a component to include a new feature are allowed.
+
+**Actions for other WGs:**
+
+- Provide a _git revision_ which the Manifests leads will use to update the files in the manifests repo
+- Provide an initial list of issues that the WG would like to close until the final release
+- Work on closing the provided open issues
+- Ensure that future_git revisions_they provide only include bug fixes, and not new features, from the previously provided _git revision_
+- Declare expected common dependency version ranges
+- Declare a WG Liaison that will be communicating with the Release Team
+
+**Actions for Manifests WG:**
+
+- Create an issue per WG for handling the communication of _git revisions_ that the WGs will be providing
+- Get a git revision from all WGs, on the first day of the Feature Freeze period. WGs need to have a git revision ready to give to the manifests WG.
+- Create a tracking issue to keep track of the pending bug fixes for each WG as well as the currently provided _git revision_
+- Push a commit that updates the manifests for the different WGs, based on the _git revision_ they had provided.
+- Create a new **vX.Y-branch** branch in the manifests repo
+- Create a new **vX.Y-rc.0** tag that will be pointing to the branch created above
+- Add commits on top of the **vX.Y-branch** branch to include bug fixes. The other WGs can provide a new _git revision_ to Manifests WG leads. The new git revision must only include bug fixes, not new features.
+- On the last day of feature freeze, cut a new **vX.Y-rc.1** RC tag on the **vX.Y-branch** release branch.
+
+**Actions for the Release Team:**
+- Generate a changelog/feature summary for the community, to be presented at the community meeting
+    - This will allow WGs to highlight their work, and also act as a checkpoint for everyone to know that they can move to documentation and testing for the rest of the cycle.
+- Identify, early in the first week, bugs at risk. These should either be aggressively fixed or punted
+
+**Success Criteria:** All working group git branches and tags are created, manifests are up to date, features either have landed or been pushed to next release.
+
+### Manifests testing (1 week)
+
+The Manifests WG leads will be evaluating the final structure of manifests before Distribution owners start testing
+
+**Actions for other WGs:**
+- Provide updates on the progress of pending issues and their fixes
+
+**Actions for Manifests WG:**
+- Ensure the manifests provide a deployable Kubeflow installation
+- Sync with other WGs on pending issues
+- After finishing testing, create a new **vX.Y-rc.2** tag on the **vX.Y-branch** release branch to ensure the latest bug fixes are included.
+
+**Success Criteria:** Manifests complete and fixes from working groups applied.
+
+### Documentation (3 weeks) (Starts the same time as Feature Freeze)
+
+Alongside the feature freeze and the continuous bug fixes we can now focus on
+ensuring that the docs are up to date, before distributions start testing.
+Features that are at risk or being worked up until the deadline
+can be documented last, ideally most of the feature work has landed already and
+those can start to be documented.
+
+**Actions for ALL WGs:** Have their documentation up to date
+
+**Actions for the Release Team:**
+- Request a list of features and deprecations, from the Working Groups, that require updates to the documentation
+- Ensure the provided component versions match the documentation
+- Work alongside the Working Groups to bring the docs up to date
+
+**Success Criteria:** Documentation for this release completed with minimum following pages updated and a new version
+in the website is cut.
+- [Installing Kubeflow](https://www.kubeflow.org/docs/started/installing-kubeflow/)
+- [Upgrade Kubeflow](https://www.kubeflow.org/docs/distributions/gke/deploy/upgrade/)
+- [Kubeflow Application Matrix](https://www.kubeflow.org/docs/reference/version-policy/#kubeflow-application-matrix)
+- [Distributions](https://www.kubeflow.org/docs/distributions/) and related pages underneath
+
+### Distribution testing (3 weeks)
+
+Distribution owners will start testing the latest RC tag and report back issues they find. Depending on the severity of the issues, and number of bug fixes that will accommodate them, the Manifests WG leads might need to cut a new RC tag.
+
+After the 3 weeks pass, for this phase, the release process will not further wait for the distributions to be ready.
+
+**Actions for other WGs:**
+
+- Evaluate which of the reported issues should be release blocking
+- Work on providing bug fixes for release blocking issues
+- Create a final git tag. It should be stable (not RC) and include fixes for release blocking issues found during this time.
+
+**Actions for Manifests WG:**
+
+- \[OPTIONAL] Create a **vX.Y-rc.3** tag, depending on the number of created issues and bug fixes
+
+**Actions for Release Team:**
+
+- Start creating the draft for the official blog post and collating information from the Working Groups
+    - (Optional but encouraged) Working Groups start drafting WG-specific blog
+        posts, deep diving into their respective areas
+- Preparation for social media posts can start at the beginning of this phase
+- Release Manager: List the features, and ideally with docs, that made it into the release
+
+**Success Criteria:** Thumbs up from distribution representatives when their testing is complete.
+
+### Release
+
+We made it!
+
+**Actions for Manifests WG:**
+
+- Create the final **vX.Y** tag, pointing to the latest commit of the release branch
+- Cut a new GitHub release in <https://github.com/kubeflow/kubeflow>
+- Cut a new GitHub release in <https://github.com/kubeflow/manifests>
+
+**Actions for Release Team:**
+
+- Publish release blog post
+- (Optional but encouraged) Working Groups publish individual deep dive blog posts on features or other work they’d like to see highlighted.
+- Publish social media posts
+- Send release announcement to kubeflow-discuss
+
+## Post Release
+
+### Patch Release
+Planning for first patch release begins. The importance of bugs is left to the
+judgement of the Working Group's tech leads and the Release Manager to decide.
+Fixes included in the patch release must satisfy the following criteria:
+* important bug fixes
+* critical security fixes
+* updates to documentation
+
+The tech leads of a WG can also coordinate and decide, alongside the
+Manifests WG tech leads and the Release Manager, if a component's versions should be
+bumped in this patch release or go to the next minor release.
+
+The Release team continues to meet regularly, as often as needed for the point
+releases. Similar to the minor release, the patch releases should have a
+tracking issue or board so that distributions can track patch releases
+independently of the minor releases.
+
+
+### Release Retrospective
+
+The Release Team should host a [blameless](https://sre.google/sre-book/postmortem-culture/)
+retrospective and capture notes with the community. The aim of this doc
+is for everyone to chime in and discuss what went well and what could be improved.

--- a/releases/release-1.4/README.md
+++ b/releases/release-1.4/README.md
@@ -1,0 +1,43 @@
+# Kubeflow 1.4
+
+### Links
+
+- [Release Team](release-team.md)
+- [Calendar](https://arrik.to/kf-release-team-cal)
+- [Meeting Notes](https://arrik.to/kf-release-team-notes)
+- [Recordings](https://arrik.to/kf-release-team-recordings)
+- [Project Board](https://github.com/orgs/kubeflow/projects/46)
+- Contact: [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) on slack
+
+### TL;DR
+
+The 1.4 release cycle is proposed as follows
+
+- **Monday, Jun 7th 2021**: Week 1 - Release Cycle Begins
+- **Sunday, Aug 15th 2021**: Week 10 - Feature Freeze
+- **Sunday, Sep 5th 2021**: Week 13 - Docs Update Ends
+- **Sunday, Sep 12th 2021**: Week 14 - Manifests Testing Ends
+- **Sunday, Sep 26th 2021**: Week 17 - Distribution Testing Ends
+- **Monday, Sep 27th 2021**: Week 17 - Kubeflow v1.4 Released
+
+## Timeline
+
+| **When** | **Week** | **Who** | **What** |
+| -------- | -------- | ------- | -------- |
+| Mon May 31st 2021 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
+| Mon Jun 7th 2021 | Week 1 | Release Manager | Start of Release Cycle |
+| Mon Jun 7th 2021 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| Sun Aug 15th 2021 | Week 10 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Sun Aug 15th 2021 | Week 10 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Sun Aug 29th 2021 | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Sun Sep 5th 2021 | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Sun Sep 5th 2021 | Week 13 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Mon Sep 6th 2021 | Week 14 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Sun Sep 26th 2021 | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Mon Sep 27th 2021 | Week 17 | Release Team | **v1.4** [Release Day](../handbook.md/#release) |
+| Mon Sep 27th 2021 | Week 17 | Release Team | Publish Release Blog |
+| TBD | TBD | Community | Release Retrospective |
+
+## Phases
+
+Please refer to the [release handbook](../handbook.md)

--- a/releases/release-1.4/release-team.md
+++ b/releases/release-1.4/release-team.md
@@ -1,0 +1,14 @@
+# Kubeflow 1.4 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**) |
+|----------|----------------------------------|
+| Release Manager | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`) |
+| Release Team Member(s) | David van der Spek (GitHub: [@DavidSpek](https://github.com/DavidSpek) / Slack: `@David van der Spek`), Malini Bhandaru (GitHub: [@mkbhanda](https://github.com/mkbhanda) / Slack: `@Malini Bhandaru`), and Rui Vasconcelos (GitHub: [@RFMVasconcelos](https://github.com/RFMVasconcelos) / Slack: `@Rui Vasconcelos`) |
+| Product Manager | Josh Bottum (GitHub: [@jbottum](https://github.com/jbottum) / Slack: `@JoshBottum`) |
+| Docs Lead | Rui Vasconcelos (GitHub: [@RFMVasconcelos](https://github.com/RFMVasconcelos) / Slack: `@Rui Vasconcelos`) |
+| Working Group Liaison(s) | <ul><li>**AutoML**: Andrey Velichkevich (GitHub: [@andreyvelich](https://github.com/andreyvelich) / Slack: `@Andrey Velichkevich`)</li><li>**Manifests**: Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`)</li><li>**Notebooks**: Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`)</li><li>**Pipelines**: Yuan Gong (GitHub: [@Bobgy](https://github.com/Bobgy) / Slack: `@Bobgy`) and James Liu (GitHub: [@zijianjoy](https://github.com/zijianjoy) / Slack: `@James Liu`)</li><li>**Serving**: Paul Van Eck (GitHub: [@pvaneck](https://github.com/pvaneck) / Slack: `@Paul Van Eck`)</li><li>**Training**: Johnu George (GitHub: [@johnugeorge](https://github.com/johnugeorge) / Slack: `@Johnu`), Jiaxin Shan (GitHub: [@Jeffwan](https://github.com/Jeffwan) / Slack: `@Jiaxin Shan`), and Yuan Tang (GitHub: [@terrytangyuan](https://github.com/terrytangyuan) / Slack: `@terrytangyuan`)</li></ul>  |
+| Distribution Representative |  |
+| Shadow(s) | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`) and Kenneth Koski (GitHub: [@knkski](https://github.com/knkski) / Slack: `@Kenneth Koski`) |
+
+- The definition of the release team roles and responsibilities can be found at [release handbook](../handbook.md)
+- The timeline for the release can be found at [release-1.4 documentation](README.md)

--- a/releases/release-1.5/README.md
+++ b/releases/release-1.5/README.md
@@ -1,0 +1,50 @@
+# Kubeflow 1.5
+
+### Links
+
+- [Release Team](release-team.md)
+- [Calendar](https://arrik.to/kf-release-team-cal)
+- [Meeting Notes](https://arrik.to/kf-release-team-notes)
+- [Recordings](https://arrik.to/kf-release-team-recordings)
+- Retrospective Document
+- Project Board
+- Contact
+  - [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) on slack
+  - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
+
+### TL;DR
+
+The 1.5 release cycle is proposed as follows
+
+- **TBD**: Week 1 - Release Cycle Begins
+- **TBD**: Week 10 - Feature Freeze
+- **TBD**: Week 13 - Docs Update Ends
+- **TBD**: Week 14 - Manifests Testing Ends
+- **TBD**: Week 17 - Distribution Testing Ends
+- **TBD**: Week 17 - Kubeflow v1.5 Released
+
+## Timeline
+
+| **When** | **Week** | **Who** | **What** |
+| -------- | -------- | ------- | -------- |
+| TBD | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
+| TBD | Week 1 | Release Manager | Start of Release Cycle |
+| TBD | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| TBD | Week 10 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| TBD | Week 10 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| TBD | Week 10 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| TBD | Week 10 | Manifest WG | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| TBD | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| TBD | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| TBD | Week 13 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| TBD | Week 13 | Manifest WG | [v1.5-rc.2 Released](../handbook.md#manifests-testing-1-week) |
+| TBD | Week 14 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| TBD | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| TBD | Week 17 | Manifest WG | (optional) [v1.5-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| TBD | Week 17 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
+| TBD | Week 17 | Release Team | Publish Release Blog |
+| TBD | TBD | Community | Release Retrospective |
+
+## Phases
+
+Please refer to the [release handbook](../handbook.md)

--- a/releases/release-1.5/release-team.md
+++ b/releases/release-1.5/release-team.md
@@ -1,0 +1,13 @@
+# Kubeflow 1.5 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**) |
+|----------|----------------------------------|
+| Release Manager | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`) |
+| Release Team Member(s) | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`) |
+| Product Manager | Josh Bottum (GitHub: [@jbottum](https://github.com/jbottum) / Slack: `@JoshBottum`) |
+| Docs Lead | Shannon Bradshaw (GitHub: [@shannonbradshaw](https://github.com/shannonbradshaw) / Slack: `@Shannon Bradshaw`) |
+| Working Group Liaison(s) | |
+| Distribution Representative |  |
+
+- The definition of the release team roles and responsibilities can be found at [release handbook](../handbook.md)
+- The timeline for the release can be found at [release-1.5 documentation](README.md)

--- a/releases/retrospectives/release-1.3.md
+++ b/releases/retrospectives/release-1.3.md
@@ -1,0 +1,253 @@
+Kubeflow 1.3 Release Retrospective
+
+
+# This meeting
+
+- **Zoom**
+
+  - **Part 1 Link: <https://us02web.zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09>**
+  - **Part 2 Link:<https://meet.google.com/xub-rfab-tak>**
+
+- **When:**
+
+  - \[done] Tuesday, May 25, 08:00 AM PT
+  - \[upcoming] Friday, May 28th, 08:00 AM PT
+
+- **Host:** Yannis Zarkadas &lt;[yanniszark@arrikto.com](mailto:yanniszark@arrikto.com)>
+
+- **Note-Keeping:** Malini Bhandaru &lt;[mbhandaru@vmware.com](mailto:mbhandaru@vmware.com)>
+
+- **Recording:**
+
+  - Part 1: https://www.youtube.com/watch?v=jbVlpsAGaV4
+  - Part 2: https://www.youtube.com/watch?v=Pr2vQxUsz_s
+
+- **Based on:** [Kubernetes Retrospective](https://docs.google.com/document/d/1Ay61Wdg_i5ss25kbzpEjT5HLnomlRg7O1acnPujIgC0/edit#heading=h.ukbaidczvy3r)
+
+
+# How this meeting works
+
+- Please fill in items below, to discuss during the meeting. These items are things you think went well or things that could have gone better.
+- Please add your name next to your added item and be ready to elaborate in the meeting.
+- Solutions are found in changing our process and tooling, not in blaming/shaming.
+- Mute when not speaking.
+
+
+# Current Processes
+
+- \[yanniszark] Most of the process is documented in issue:<https://github.com/kubeflow/manifests/issues/1777>
+- \[yanniszark] This old doc from kubeflow/kubeflow is mostly obsolete, but provides some good info on docs:<https://github.com/kubeflow/kubeflow/blob/2d845ee97da9650171701126ad56b34fddd51a7c/docs_dev/releasing.md>
+
+
+# What went well in 1.3
+
+- \[yanniszark] We successfully released with our new WG community structure.
+
+- \[yanniszark] Major release with a lot of features across Working Groups.
+
+- \[yanniszark] Simplified manifests and installation process.
+
+- \[yanniszark] Sending frequent release updates in the “kubeflow-discuss” mailing list was very useful for people that don’t closely monitor community meetings.
+
+  - \[Malini Bhandaru] I agree the release related emails were on point and highlighted the need of the hour such as distribution completeness/testing etc.
+  - \[nakfour] release updates and emails were excellent.
+
+- \[josh] Meeting notes were better documented and sent to the mailing list
+
+- \[rui] Great docs completely new docs on KFP contributed by Google
+
+- \[rui] Openness to refactor very high level things like Getting Started and good collaboration between organizations
+
+
+# What could have gone better in 1.3
+
+
+## General
+
+- \[yanniszark] Exact timeline for each release phase was not announced from the start of the release. As a result, some people were confused.
+
+  - **ACTION:Publish exact timeline well in advance**
+
+- \[yanniszark] We had no strict definition of release phases (feature freeze / release candidate, manifests testing, distribution testing), so some people were confused about whether new features could be included.
+
+  - **ACTION:Terminology about release phases. For example, what exactly does “Release Candidate” mean? Define it strictly.**
+
+- \[davidvanderspek and Juana Nakfour ] Automate the way we sync the manifests repo by defining how versions of Kubeflow relate to versions of individual components.
+
+- \[yanniszark] We scheduled some deadlines on days OTHER than community meetings. Deadlines SHOULD always be scheduled on the day of a community meeting OR the one after it, so that we have a chance to sync about the deliverable as a community. -- agree! Malini; mid-week actually good - it protects weekend and Monday holidays
+
+  - \[jamesliu] If we do it on the next day, will people chase the deadline?
+
+- \[yanniszark] We scheduled some deadlines on days that were public holidays. We SHOULD always try to account for holidays before scheduling a deadline.
+
+- \[yanniszark] We did not cut a stable release for kubeflow/kubeflow for 1.3, because there were no additional changes. However, we should always cut a stable release, even if it’s the same as the previous RC.
+
+  - **ACTION:** Add an explicit step, after distributions testing (aka before the final stable release), to cut stable releases for all kubeflow components if needed.
+
+- \[yanniszark] We did not create a GitHub release after cutting a tag. GitHub releases are a GitHub-specific wrapper around git tags. Since these are user-visible objects and we have used them before, we should make sure to continue using them, in order to not confuse users.
+
+  - \[david van der spek] more automation would help here.
+  - \[juana] can add a tag now. Yannis has a PR out today to do just that.
+  - \[Rui] The latest release in[Kubeflow/Kubeflow](https://github.com/kubeflow/kubeflow) and in [Kubeflow/Manifests](https://github.com/kubeflow/manifests) is still v1.2, this is confusing.
+  - \[andrew scribner] People in Statistic Canada were not sure if 1.2 was released. Not clear what the authoritative source was. people keep abreast of change by setting notifications on tags, so such tags help..
+  - \[James Liu] Agree to create GitHub release, Google distribution and KFP are currently doing this.**Pinned issues**.<https://docs.google.com/document/d/1KRF4IE48Ueb61DPBKK6fryRWSaNz_urXQOxWf4G_qD8/edit?pli=1#>
+  - \[Jeff Fogarty] why did we not make a github release. -
+  - \[johnu George]
+  - Yannis, not a procedural issue. We should not miss this next time. In this case there were no bugs between release candidate and final, thus it was a forgotten step.
+  - **ACTION: Add an explicit step, after the previously-mentioned step to release Kubeflow components.**
+
+- \[yanniszark] In some WGs, there was some confusion over what features should make it in the release. WGs should make an effort to discuss this at the beginning of the release cycle, so that there is no confusion afterwards.
+
+  - \[johnu] Priority tags during releases. In order for people to understand what we are working on.
+  - \[Yannis] towards the end of the release these were useful, but several of the items had the same P1 priority which did not help.
+  - \[johnu] some items were long standing issues. Eg pipelines - in cluster issues, default installation of kubeflow has -- document known issues, what works/does not/ -- collect these and capture handling them with fixes/workarounds etc. Also crowd source issue triaging, like upvote issues that affect them.
+  - \[yannis] perhaps WGs could create an umbrella issue that itemizes issues they plan to work on and prioritize, so everything is in one place.
+
+This also helps with aspirational goals of items they want fixed and what actually gets done -- because some are more convoluted than others.
+
+- \[yanniszark] Some actions required coordination across timezones.
+
+  - **ACTION:** Document that release team members should be added to the release ACL, in order to be able to cut branches themselves: <https://github.com/kubeflow/internal-acls/pull/441>
+  - **ACTION:** The release team should have members in different timezones to account to ease the burden.
+
+- \[yanniszark] Many WGs had no established process in place for releasing manifests. Most have adopted a process with release branches, which allow for minor releases without slowing down development in master:<https://github.com/kubeflow/katib/issues/1474>
+
+  - **ACTION:** Make sure that each WG has a clear, documented release process defined for their repos.
+  - \[Andrey Velichkevich] could all WGs adopt the same process for manifest release. Branches and tags.
+  - \[yannis] a first step would be to document what is currently in place in WG and then compare.
+
+- \[yanniszark] When cutting a new release branch in a repo, Prow testing is not enabled.
+
+  - **ACTION:** Document the exact process. See: <https://github.com/kubeflow/testing/pull/936>
+
+- \[jbottum] we should consider producing a changelog or similar for each release. It would be nice to have a count of issues and PR closed in each release. +1 Malini
+
+  - \[malini] github tag for user related issues, they do it k8s (?)
+  - \[yanniszark] changelog per wg?
+  - Concept and purpose:[https://github.com/github-changelog-generator/github-changelog-generator
+    ](https://github.com/github-changelog-generator/github-changelog-generator)\[Bobgy]: KFP had some painful memories using github-changelog-generator, for context:[\[Release\] Changelog Process after 1.0 · Issue #3920 · kubeflow/pipelines](https://github.com/kubeflow/pipelines/issues/3920)
+  - Size features - small/medium/large/extra large. XL might be a feature that gets implemented spread over multiple releases.
+  - \[kimonas] We’ve not used changelogs in manifests, but keen on seeing what pipelines is doing to see if we can replicate a common method.
+  - Action item: research what tools are available and philosophy - user-facing changes captured in release notes and all changes separately (changelog)
+
+- \[jbottum] we should consider defining terms for distributions to report their release process
+
+  - \[jorge castro] Collect and update for each downstream distribution - GCP, AWS, Azure, OpenShift ..a running tally/status of progress. “Distribution readiness” single page was used in the past. Have distributions to assigning a person, contact person, to contact and get updates when necessary. Create issues and set up notifications for the same.
+  - \[yanniszark] Previous issue for tracking distribution progress:<https://github.com/kubeflow/manifests/issues/1798>
+  - Something that makes this view to be more granular -- like testing has started, expected completion etc.
+
+- \[jbottum] we should request the Working Groups to provide a status to the Release Manager, potentially in writing if they are not going to attend the weekly status call, even if the update is “no change”. Also having a WG just send an update to the kubeflow-discuss list can be a good way for WGs whoo can’t attend a status call to just send an update asynchronously. +1 Malini
+
+- These dependencies per sub-project is a list of dependenciesand their their version. Want consistency on dependency version consistency across all the sub-projects.
+
+  -
+
+
+- \[jbottum] we should consider a list of dependencies and report on which versions we are expecting to develop and test with i.e. istio, knative, kubernetes,
+
+  - \[yanniszark] SDKs can also have incompatible dependencies
+  - \[malini] Perhaps there is a tool for this?
+
+- \[jbottum] At the beginning of each release cycle, each Kubeflow Working Group should schedule and present their current roadmap (what and why)
+
+in a Tuesday Community Meeting.
+
+- \[jorge] perhaps in this meeting also demo the features released in the previous rele +1 Kimonas
+
+- \[James Liu] Currently we are manually testing full fledged Kubeflow, it will be great to identify the scope of supported functionality during Kubeflow release, and write tests to automate this validation. It can reduce the complexity of future releases.
+
+  - \[Andrey V] what platform will we use for testing each release. What is a generic kubernetes? EKS. What do we communicate to our users?
+  - \[yannis] we are telling our users we are “pretty confident” and they can select a downstream distribution version to test on their own if they want additional support or could opt for minikube etc..
+  - \[malini] how is the base kubernetes selected for each release development effort .. not the bleeding edge.
+  - \[yannis] In the past a “popular” one was used but this may need to be formalized, perhaps a matrix of K8 versions that will be explored?
+
+- \[johnu george] - create a release thread/issue and sub-threads for documentation, blocker issues are all taken care of. +1 yannis
+
+- \[Johnu] Like in earlier releases, we can tag issues with release tag and priority so that they can be tracked for each release. This will help in prioritizing features and in bringing better clarity to users. If a fix/feature is agreed upon as p0 for a release, it is a blocker and needs to be fixed before cutting the release. It also becomes easy to figure out what fixes have gone in(Referring to Josh’s earlier comment)
+
+- \[David] version dependencies - KF_serving and pipelines version were different in notebook -- such as SDK etc. These should be made compatible.
+
+- \[Malini] libraries of third party dependencies too - example boto3.
+
+- \[yannis] PR in test repo too.
+
+- \[nakfour] The time between KF 1.3 first cut and distribution support was too short, I think 1-2wks
+
+- \[yannis] we could send more frequent updates when there are delays
+
+- \[andrey v] - WGs are using different release processes with respect to cutting the branch and tagging.
+
+- \[yannis] kfserving, katib and notebook use release branches. Pipelines uses tags. Release branches bring the benefit of allowing continued work on the master.
+
+- \[andrey] istio follows new branch from master when they are ready to do a release.
+
+- \[yannis] istio then cheery picks any bug fixes and merges to the release branch. Katib has documented this process. Similar documentation of this available in kubeflow/kubeflow.
+
+- \[andrey v] what about a consistent way to push images to repositories/registries, to publish images. Registry provider.. Andrey to provide additional details here.
+
+  - ECR issue:<https://github.com/kubeflow/kubeflow/issues/5922>
+
+- \[johnu] allow sub-projects to use their own registries
+
+  - <https://github.com/kubeflow/kubeflow/blob/master/releasing/README.md>
+
+- \[nakfour] release delays need more elaborate information on blocking issues and estimated new release dates
+
+- \[Andrey] Can we follow the same release process for all WGs? Image registries, CI/CD, etc.
+
+  - Clear plan for all WGs to follow a single release process? Do we want a single release process?
+
+
+## Docs
+
+- \[yanniszark] In our current process, we first release and then focus on docs. Should we instead focus on docs when a feature goes in and not release until we have good documentation? \[+1 Rui]
+
+- \[yanniszark] Is the[current process](https://github.com/kubeflow/kubeflow/blob/2d845ee97da9650171701126ad56b34fddd51a7c/docs_dev/releasing.md#version-the-website) for the website up-to-date? Who has the permissions to follow it?
+
+  - \[rui] Not 100% up to date, but still very relevant
+
+- \[rui] WG ownership of their docs was low. We had things like training operators outdated for months
+
+- \[malini] would it make sense to have advertised doc hackathon days? To get all eyes on it.
+
+- \[shannon Bradshaw] pro-actively call out updates that will break some doc obsolete - impact of features on doc
+
+- \[david] code-doc if they co-reside, more likely they will be in sync as opposed to a separate website.
+  -\[Bobgy] +100 to this, ideally PRs should contain both doc and code changes at the same time.[Breaking up the website to each WG is a prerequisite.](https://github.com/kubeflow/website/issues/2293#issuecomment-718481321)
+
+- \[yannis] would like to suggest that WG consider doc writing as part of feature release as opposed to a separate after step. Completeness is implementation with its docs. - Shannon, Malini etc agree on this.
+
+- \[josh] how much does the open source documentation have to do given there may be different plugins/implementations. Should we articulate some template/minimum expectations wrt docs.
+
+- \[david] what parts of the docs fall in the purview of KF and what falls into the distros.
+
+- \[yannis] identify an issue that is extreme to clarify the above as example.
+
+- \[josh] Users should provide feedback about whether some docs are adequate. Users should be part of the release process to look at the docs on par with developers. Users to QA/vet the docs - perhaps when the RC goes out. A comment period.
+
+- \[yannis] distros are our first users. But end users who consume it all.
+
+- \[josh] we get dinged on docs, let us formally invite them to be part of the process for testing it. There are 2 sets of users, beta and GA users, giving feedback during document creation.
+
+- \[malini]the docs do have links within to help people file issues.
+
+- \[yannis] demonstrated what is available
+
+- \[josh]**docs sprints** -- users/everyone take a look and provide comments. A lot of this has fallen on Rui and do not want to overload him, people to help.
+
+- \[kimonas] feature complete requires documentation. A template too for new feature proposal, what all it affects -- APIs/tests, documentation, performance.
+
+- \[andrey] all working groups should follow the same pattern. +1 Kimonas
+
+- \[yannis] PR template
+
+- \[yannis] release handbook
+
+
+# Next Steps
+
+- For 1.4, one of the core deliverables will be to contribute upstream a detailed release document from all the learning so far, so after 1.4, everyone can follow it and the release process can really scale.
+- The KFP and KFServing SDKs had conflicting dependencies making them incompatible with each other. All SDKs should have the same dependency requirements so they are compatible with each other.
+
+
+

--- a/releases/retrospectives/release-1.4.md
+++ b/releases/retrospectives/release-1.4.md
@@ -1,0 +1,82 @@
+# Kubeflow 1.4 Release Retrospective
+- [Original Documentation](https://docs.google.com/document/d/119PCr2h3Wwm7XA_qHqtda017Q--yWPF9u7nuUWo0ZnY/edit?usp=sharing)
+
+Now that we’ve released 1.4 we would like to follow up with a retrospective to gather feedback on what went well and, most importantly, where we can improve. This document aims to provide a collaboration medium for people to write their feedback on. 
+
+The release team will go over the provided feedback on Monday, November 8th, provide a summary and sort the items. Then the team will expose the summary in the next Community Meeting on Tuesday, November 9th.
+
+### Links
+- [Handbook](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/handbook.md) 
+- [Release Team](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/release-1.4/release-team.md) 
+- [Timeline](https://github.com/kubeflow/manifests/tree/v1.4.0/docs/releases/release-1.4) 
+
+### Rules
+- Respectful, solution-oriented communication
+- Solutions are found in changing our process and tooling, not in blaming/shaming
+
+## What went well ✅
+- [Kimonas Sotirchos] The timeline was defined from the start of the release process
+- [Kimonas Sotirchos] More clear overview of the different phases
+- [Kimonas Sotirchos] Very good and timely communication with all WG leads
+- [Kimonas Sotirchos] A dedicated release team
+- [Kimonas Sotirchos] Regular meetings to discuss the progress of the release
+  - **[Action Item]** Any announcement the release team send out, include links to release resources - add to release handbook
+  - **[Action Item]** Add release info to the website for visibility - create an issue to track
+- [Josh Bottum] Better communication with the distribution owners
+- [Josh Bottum] Better quality of the release
+  - [Kimonas Sotirchos] Release timeline went well with WG timelines
+  - **[Action Item]** Get release schedule feedback from WG - add to release handbook
+- [Josh Bottum] Feature roadmap presentation for the community in the beginning of the release
+  - [Anna] It could help the WGs to start having the release in mind and start planning
+  - [Andrey] Some WG might not have a new release synced with the KF release. Let’s not enforce that WGs also sync their releases with KF
+  - [Kimonas] Lets actually discuss this more after we do a first feedback meet with WGs
+
+## What could have gone better ⚠️
+- [Kimonas Sotirchos] More emails to the mailing list, so that people not following GitHub can also stay up to date with what’s going on, blockers etc
+  - [Anna] Is there a better way to get WG and/or distribution owners attention
+  - [Andrey] We also have the announcements channel
+  - [Anna] We could also create slack groups
+  - [Kimonas] Lets try to keep the context in GitHub though, even if we use slack
+  - **[Action Item]** Duplicate kubeflow-discuss announcements in slack - add to release handbook
+- [Kimonas Sotirchos] An automated way of syncing manifests from other repos to the manifests repo
+- [Kimonas Sotirchos] We had a manual process for testing the provided manifests, which required cycles
+  - [Kimonas] The AutoML WG leads had created a notebook that the GCP folks used for evaluating their distro. We could convert to a py script and run it with prow [https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb) 
+  - [Juana] Maybe we could only run this nightly
+  - [Andrew Scribner] Conformance tests were raised in the kubeflow conformance program discussion.  It would be ideal if these tests were sync’d as the goal of the tests sound very similar - we are trying to prove we have a fully functioning kubeflow
+    - [Anna] Shouldn’t the provided manifests after each release also pass the conformance tests? +1 Kimonas
+    - [Kimonas] We could make this more explicit as we go forward
+- Create an issue to track [the release] +1 Kimonas
+  - **[Action Item]** Add the step to create an issue in the handbook
+- [Kimonas Sotirchos] We should have cut the branch for 1.3 previous release early on. The 1.3 docs ended up having some content that corresponded to 1.4
+  - **[Action Item]** Update docs for versioning/cutting branch for the release to follow the new process
+- [Kimonas Sotirchos] A lot of docs PRs still happened in the end of the release timeline
+  - [Shannon] Provide guideline on how doc process/reviews work
+  - [Andrey] Define owners for each website file
+  - [Anna] We could have prow to check if a PR has a corresponding docs PR
+  - **[Action Item]** Remove documentation phase and enforce WG to have docs as part of development phase - propose to WG leads
+- [Josh Bottum] Document the process for the release blog post
+- [Josh Bottum] Document the process for the release video presentation
+- [Josh Bottum] We could use more user input on features and more user contributions
+  - [Issue](https://github.com/kubeflow/community/issues/530) already created to track 
+- [Andrey Velichkevich] Decrease the Feature Freeze timeline
+  - [kimonas] We can move the Manifests Testing to the second week in the Feature Freeze phase
+  - [kimonas] Lets also write down the main criteria for reducing feature freeze:
+    - Having enough CI/CD in place to run tests in an automated manner
+    - Ask if the WG leads feel comfortable stabilizing their components with the proposed time frame (for example 1 week of Feature Freeze in the future)
+    - [Andrey] It would be good to have the big PRs merged even before the feature freeze, since we will also be tackling the docs PRs for these features in parallel +1 Kimonas
+    - [Anna] It’s also good to explicitly mention the deadlines
+- [Anna Jung] Team selection process
+  - [Anna] Should we keep on having nominations? +1 Kimonas
+  - [Anna] Shouldn’t the release team be able to select the next release team? +1 Kimonas
+  - [Anna] We should still use the mailing list to ask for volunteers for shadows, but not for the lead roles +1 Kimonas
+  - [Anna] Let’s also have a limit to how many times someone can run the release consecutively. This will help ensure that people can come, use the handbook and successfully drive the release +1 Kimonas
+  - [Anna] We should start defining even more the skill and effort required for the role of the Release Manager, so that people can be prepared for what they are signing in for
+- [Anna Jung] Delay in release
+- [Anna Jung] Responsibility of the release team
+  - [Anna] Let’s also ensure we ask new members if they would like to lead following releases
+  - [Kimonas] Let’s think about removing one of the Release Team member or Shadow roles
+- [Anna Jung] Add release candidates to the timeline
+  - Lets add this information in the tables in the [timeline](https://github.com/kubeflow/manifests/tree/master/docs/releases/release-1.4#timeline) and [handbook](https://github.com/kubeflow/manifests/blob/master/docs/releases/handbook.md#timeline) 
+- Move release docs to community rep? [Anna Jung]
+  - **[Action Item]** Create an issue to move the kubeflow/manifests/docs/releases folder under kubeflow/community
+  - [Kimonas] Let’s ensure that the OWNERS file will include the release team to allow us to keep on iterating fast 


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Move release-related documentation from [manifest/docs](https://github.com/kubeflow/manifests/tree/master/docs) to community repository
- Add 1.4 release retrospective document
- Add initial 1.5 release timeline document
- Add initial 1.5 release team document
- Add README with link to release resources
- Add OWNERS file with initial 1.5 release team members

ref: https://github.com/kubeflow/community/issues/531 Proposal to relocate release related document

cc @shannonbradshaw @kimwnasptd @jbottum 