### PR TITLE
Improve the handbook with feedback from the 1.4 Release Retro

### DIFF
--- a/releases/.gitignore
+++ b/releases/.gitignore
@@ -1,0 +1,7 @@
+# vim
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -194,7 +194,11 @@ Criteria for timeline that the team needs to consider
 - Kubecon dates - let’s not hard block on events, but keep them in mind since we know community members might get doublebooked.
 - Associated events (aka. AI Day at Kubecon, Tensorflow events) - we want to keep them in mind.
 
-**Success Criteria:** Release team selected, schedule sent to kubeflow-discuss, all release team members have the proper permissions and are meeting regularly.
+**Success Criteria:**
+* Release team selected
+* Schedule sent to kubeflow-discuss
+* All release team members have the proper permissions and are meeting regularly
+* A tracking issue for the release has been created in kubeflow/community
 
 
 ### Development (10 weeks)

--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -199,6 +199,22 @@ Criteria for timeline that the team needs to consider
 * All release team members have the proper permissions and are meeting regularly
 * A tracking issue for the release has been created in kubeflow/community
 
+#### Release Team Selection
+
+The leads of the current release team will be selecting their successors for
+the next release. This should also take place before the current release team
+holds the release retrospective, in order for the new team to be able to
+provide feedback.
+
+The process for selecting shadows and members will be different though. In this
+case we want to welcome as many members as possible to join the release team.
+The release team should make an outreach via the available channels,
+mailing-list, slack, GitHub, and ask for volunteers that would like to
+participate in the release team.
+
+We currently don't have a limit on how many consecutive times someone can be a
+release manager, but it is hightly recommended that this role is rotated. This
+will allow us to further evolve our process and handbook.
 
 ### Development (10 weeks)
 

--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -205,7 +205,10 @@ Criteria for timeline that the team needs to consider
 Normal development in the different WGs and in the <https://github.com/kubeflow/manifests> repo.
 
 **Success Criteria:**
-* (Optional but encouraged): Issues tracking new features should also provide information on whether the docs should be updated for that feature
+* (Optional but encouraged): Issues tracking new features should also have a
+  corresponding docs PR that gets developed in parallel with the feature.
+  This will help keep track of PRs at risk during the Feature Freeze phase as
+  well as evaluate the docs effort early.
 
 
 ### Feature Freeze (2 weeks)

--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -155,26 +155,25 @@ The manifests repo will be following the release process below:
 
 
 ## Timeline
-
-| Week | Events |
-| --- | --- |
-| 1 | Development |
-| 2 |   |
-| 3 |   |
-| 4 |   |
-| 5 |   |
-| 6 |   |
-| 7 |   |
-| 8 |   |
-| 9 |   |
-| 10 |   |
-| 11 | Feature Freeze, Documentation |
-| 12 |   |
-| 13 | Manifests testing week |
-| 14 | Distributions testing |
-| 15 |   |
-| 16 |   |
-| 17 | Release |
+| **Week** | **Who** | **What** |
+| -------- | ------- | -------- |
+| Week 0 | Release Manager | [Preparation](#preparation) |
+| Week 1 | Release Manager | Start of Release Cycle |
+| Week 1 | Community | [Development](#development-10-weeks) |
+| Week 10 | Release Team | [Feature Freeze](#feature-freeze-2-weeks) |
+| Week 10 | Manifest WG | [rc.0 Released](#feature-freeze-2-weeks) |
+| Week 10 | Docs Lead | [Documentation](#documentation) |
+| Week 10 | Manifest WG | [rc.1 Released](#feature-freeze-2-weeks) |
+| Week 12 | Release Team | [Manifests Testing](#manifests-testing-1-week) |
+| Week 13 | Docs Lead | End of [Documentation](#documentation) |
+| Week 13 | Release Team | End of [Manifests Testing](#manifests-testing-1-week) |
+| Week 13 | Manifest WG | [rc.2 Released](#manifests-testing-1-week) |
+| Week 14 | Release Team and Distribution Representative | [Distribution Testing](#distribution-testing-3-weeks) |
+| Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](#distribution-testing-3-weeks) |
+| Week 17 | Manifest WG | (optional) [rc.3 Released](#distribution-testing-3-weeks) |
+| Week 17 | Release Team |  [Release Day](#release) |
+| Week 17 | Release Team | Publish Release Blog |
+| TBD | Community | Release Retrospective |
 
 
 ### Preparation


### PR DESCRIPTION
I'm augmenting the release handbook to include discussion points from the 1.4 release retro we had  https://github.com/kubeflow/community/blob/master/releases/retrospectives/release-1.4.md 

Points addressed:
1. Release team selection process
2. Encouragement to have docs PRs alongside feature PRs
3. Add more details in the Timeline, regarding RCs
4. Explicitly mention that we should also have a tracking issue for the release

I also think that we should look into breaking the handbook into some smaller files, like `roles`, `timeline` etc. It's currently a huge 300+ lines and will keep getting bigger.

/cc @annajung 
/cc @shannonbradshaw 
/cc @jbottum 