### PR TITLE
Add dates to the 1.5 release timeline

### DIFF
--- a/releases/release-1.5/README.md
+++ b/releases/release-1.5/README.md
@@ -23,26 +23,34 @@ The 1.5 release cycle is proposed as follows
 - **TBD**: Week 17 - Distribution Testing Ends
 - **TBD**: Week 17 - Kubeflow v1.5 Released
 
+- **Thursday, Oct 21st 2021**: Week 1 - Release Cycle Begins
+- **Thursday, Jan 13th 2021**: Week 12 - Feature Freeze
+- **Friday, Jan 14th 2021**: Week 12 - Manifests Testing Starts
+- **Thursday, Jan 20th 2021**: Week 13 - Docs Update Ends
+- **Thursday, Jan 27th 2021**: Week 14 - Manifests Testing Ends
+- **Thursday, Feb 3rd 2021**: Week 15 - Distribution Testing Starts
+- **Wednesday, Feb 23rd 2021**: Week 17 - Distribution Testing Ends
+- **Thursday, Feb 24th 2021**: Week 17 - Kubeflow v1.5 Released
+
 ## Timeline
 
 | **When** | **Week** | **Who** | **What** |
 | -------- | -------- | ------- | -------- |
-| TBD | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
-| TBD | Week 1 | Release Manager | Start of Release Cycle |
-| TBD | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
-| TBD | Week 10 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
-| TBD | Week 10 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
-| TBD | Week 10 | Docs Lead | [Documentation](../handbook.md#documentation) |
-| TBD | Week 10 | Manifest WG | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| TBD | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| TBD | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| TBD | Week 13 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| TBD | Week 13 | Manifest WG | [v1.5-rc.2 Released](../handbook.md#manifests-testing-1-week) |
-| TBD | Week 14 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| TBD | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| TBD | Week 17 | Manifest WG | (optional) [v1.5-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
-| TBD | Week 17 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
-| TBD | Week 17 | Release Team | Publish Release Blog |
+| Mon Oct 11th 2021 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
+| Thu Oct 21st 2021 | Week 1 | Release Manager | Start of Release Cycle |
+| Thu Oct 21st 2021 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| Thu Jan 13th 2021 | Week 12 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Thu Jan 13th 2021 | Week 12 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Thu Jan 13th 2021 | Week 12 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Fri Jan 14th 2021 | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Thu Jan 20th 2021 | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Thu Jan 27th 2021 | Week 14 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Thu Jan 27th 2021 | Week 14 | Manifest WG | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Thu Feb 3rd 2021 | Week 15 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Feb 23rd 2021 | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Feb 23rd 2021 | Week 17 | Manifest WG | (optional) [v1.5-rc.2 Released](../handbook.md#distribution-testing-3-weeks) |
+| Thu Feb 24th 2021 | Week 17 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
+| Thu Feb 24th 2021 | Week 17 | Release Team | Publish Release Blog |
 | TBD | TBD | Community | Release Retrospective |
 
 ## Phases

--- a/releases/release-1.5/README.md
+++ b/releases/release-1.5/README.md
@@ -16,21 +16,14 @@
 
 The 1.5 release cycle is proposed as follows
 
-- **TBD**: Week 1 - Release Cycle Begins
-- **TBD**: Week 10 - Feature Freeze
-- **TBD**: Week 13 - Docs Update Ends
-- **TBD**: Week 14 - Manifests Testing Ends
-- **TBD**: Week 17 - Distribution Testing Ends
-- **TBD**: Week 17 - Kubeflow v1.5 Released
-
 - **Thursday, Oct 21st 2021**: Week 1 - Release Cycle Begins
-- **Thursday, Jan 13th 2021**: Week 12 - Feature Freeze
-- **Friday, Jan 14th 2021**: Week 12 - Manifests Testing Starts
-- **Thursday, Jan 20th 2021**: Week 13 - Docs Update Ends
-- **Thursday, Jan 27th 2021**: Week 14 - Manifests Testing Ends
-- **Thursday, Feb 3rd 2021**: Week 15 - Distribution Testing Starts
-- **Wednesday, Feb 23rd 2021**: Week 17 - Distribution Testing Ends
-- **Thursday, Feb 24th 2021**: Week 17 - Kubeflow v1.5 Released
+- **Thursday, Jan 13th 2021**: Week 13 - Feature Freeze
+- **Thursday, Jan 27th 2021**: Week 15 - Manifests Testing Starts
+- **Thursday, Feb 3rd 2021**: Week 16 - Manifests Testing Ends
+- **Thursday, Feb 3rd 2021**: Week 16 - Docs Update Ends
+- **Friday, Feb 4th 2021**: Week 16 - Distribution Testing Starts
+- **Wednesday, Feb 23rd 2021**: Week 19 - Distribution Testing Ends
+- **Thursday, Feb 24th 2021**: Week 19 - Kubeflow v1.5 Released
 
 ## Timeline
 
@@ -39,18 +32,19 @@ The 1.5 release cycle is proposed as follows
 | Mon Oct 11th 2021 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
 | Thu Oct 21st 2021 | Week 1 | Release Manager | Start of Release Cycle |
 | Thu Oct 21st 2021 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
-| Thu Jan 13th 2021 | Week 12 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
-| Thu Jan 13th 2021 | Week 12 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
-| Thu Jan 13th 2021 | Week 12 | Docs Lead | [Documentation](../handbook.md#documentation) |
-| Fri Jan 14th 2021 | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Thu Jan 20th 2021 | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| Thu Jan 27th 2021 | Week 14 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Thu Jan 27th 2021 | Week 14 | Manifest WG | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| Thu Feb 3rd 2021 | Week 15 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Feb 23rd 2021 | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Feb 23rd 2021 | Week 17 | Manifest WG | (optional) [v1.5-rc.2 Released](../handbook.md#distribution-testing-3-weeks) |
-| Thu Feb 24th 2021 | Week 17 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
-| Thu Feb 24th 2021 | Week 17 | Release Team | Publish Release Blog |
+| Thu Jan 13th 2021 | Week 13 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Thu Jan 13th 2021 | Week 13 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Thu Jan 13th 2021 | Week 13 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Thu Jan 27th 2021 | Week 15 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Thu Jan 27th 2021 | Week 15 | Release Team | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Thu Feb 3rd 2021 | Week 16 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Thu Feb 3rd 2021 | Week 16 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Thu Feb 3rd 2021 | Week 16 | Manifest WG | [v1.5-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
+| Fri Feb 4th 2021 | Week 16 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Feb 23rd 2021 | Week 19 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Feb 23rd 2021 | Week 19 | Manifest WG | (optional) [v1.5-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Thu Feb 24th 2021 | Week 19 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
+| Thu Feb 24th 2021 | Week 19 | Release Team | Publish Release Blog |
 | TBD | TBD | Community | Release Retrospective |
 
 ## Phases


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Based on the [release team meeting on Nov. 22nd](https://docs.google.com/document/d/1Cs9XYl_SHfGP9vs1eHyqb6JAcpE3ilM-5iRuBnV9AB4/edit?usp=sharing), the release team proposes the following dates for the 1.5 release.

Important dates are outlined below:
- **Thursday, Oct 21st 2021**: Week 1 - Release Cycle Begins
- **Thursday, Jan 13th 2021**: Week 13 - Feature Freeze
- **Thursday, Jan 27th 2021**: Week 15 - Manifests Testing Starts
- **Thursday, Feb 3rd 2021**: Week 16 - Manifests Testing Ends
- **Thursday, Feb 3rd 2021**: Week 16 - Docs Update Ends
- **Friday, Feb 4th 2021**: Week 16 - Distribution Testing Starts
- **Wednesday, Feb 23rd 2021**: Week 19 - Distribution Testing Ends
- **Thursday, Feb 24th 2021**: Week 19 - Kubeflow v1.5 Released

Note: All release phases have increased 2 weeks to accommodate for the end of the year holiday season. 1.5 release will be 19 weeks instead of 17 weeks 

cc @kimwnasptd @jbottum @shannonbradshaw 