### PR TITLE
retro-1.4: Add links to the recordings

### DIFF
--- a/releases/retrospectives/release-1.4.md
+++ b/releases/retrospectives/release-1.4.md
@@ -1,18 +1,23 @@
 # Kubeflow 1.4 Release Retrospective
 - [Original Documentation](https://docs.google.com/document/d/119PCr2h3Wwm7XA_qHqtda017Q--yWPF9u7nuUWo0ZnY/edit?usp=sharing)
 
-Now that we’ve released 1.4 we would like to follow up with a retrospective to gather feedback on what went well and, most importantly, where we can improve. This document aims to provide a collaboration medium for people to write their feedback on. 
+Now that we’ve released 1.4 we would like to follow up with a retrospective to gather feedback on what went well and, most importantly, where we can improve. This document aims to provide a collaboration medium for people to write their feedback on.
 
 The release team will go over the provided feedback on Monday, November 8th, provide a summary and sort the items. Then the team will expose the summary in the next Community Meeting on Tuesday, November 9th.
 
 ### Links
-- [Handbook](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/handbook.md) 
-- [Release Team](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/release-1.4/release-team.md) 
-- [Timeline](https://github.com/kubeflow/manifests/tree/v1.4.0/docs/releases/release-1.4) 
+- [Handbook](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/handbook.md)
+- [Release Team](https://github.com/kubeflow/manifests/blob/v1.4.0/docs/releases/release-1.4/release-team.md)
+- [Timeline](https://github.com/kubeflow/manifests/tree/v1.4.0/docs/releases/release-1.4)
+- Recondrings
+  - [Part 1](https://drive.google.com/file/d/1MxOzR4wgvETfhLv_74wEkAdkElGSPeTm/view)
+  - [Part 1](https://drive.google.com/file/d/1wz-jIAOSw3N7V9XHxPoDIEfv5hOdFFn1/view)
 
 ### Rules
 - Respectful, solution-oriented communication
 - Solutions are found in changing our process and tooling, not in blaming/shaming
+
+# Part 1
 
 ## What went well ✅
 - [Kimonas Sotirchos] The timeline was defined from the start of the release process
@@ -40,12 +45,12 @@ The release team will go over the provided feedback on Monday, November 8th, pro
   - **[Action Item]** Duplicate kubeflow-discuss announcements in slack - add to release handbook
 - [Kimonas Sotirchos] An automated way of syncing manifests from other repos to the manifests repo
 - [Kimonas Sotirchos] We had a manual process for testing the provided manifests, which required cycles
-  - [Kimonas] The AutoML WG leads had created a notebook that the GCP folks used for evaluating their distro. We could convert to a py script and run it with prow [https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb) 
+  - [Kimonas] The AutoML WG leads had created a notebook that the GCP folks used for evaluating their distro. We could convert to a py script and run it with prow [https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb)
   - [Juana] Maybe we could only run this nightly
-  - [Andrew Scribner] Conformance tests were raised in the kubeflow conformance program discussion.  It would be ideal if these tests were sync’d as the goal of the tests sound very similar - we are trying to prove we have a fully functioning kubeflow
+  - [Andrew Scribner] Conformance tests were raised in the kubeflow conformance program discussion.  It would be ideal if these tests were sync’d as the goal of the tests sound very similar - we are trying to prove we have a fully functioning kubeflow **(Discussed in Part 2)**
     - [Anna] Shouldn’t the provided manifests after each release also pass the conformance tests? +1 Kimonas
     - [Kimonas] We could make this more explicit as we go forward
-- Create an issue to track [the release] +1 Kimonas
+- [Andrew Scribner] Create an issue to track [the release] +1 Kimonas **(Discussed in Part 2)**
   - **[Action Item]** Add the step to create an issue in the handbook
 - [Kimonas Sotirchos] We should have cut the branch for 1.3 previous release early on. The 1.3 docs ended up having some content that corresponded to 1.4
   - **[Action Item]** Update docs for versioning/cutting branch for the release to follow the new process
@@ -54,10 +59,12 @@ The release team will go over the provided feedback on Monday, November 8th, pro
   - [Andrey] Define owners for each website file
   - [Anna] We could have prow to check if a PR has a corresponding docs PR
   - **[Action Item]** Remove documentation phase and enforce WG to have docs as part of development phase - propose to WG leads
+
+# Part 2
 - [Josh Bottum] Document the process for the release blog post
 - [Josh Bottum] Document the process for the release video presentation
 - [Josh Bottum] We could use more user input on features and more user contributions
-  - [Issue](https://github.com/kubeflow/community/issues/530) already created to track 
+  - [Issue](https://github.com/kubeflow/community/issues/530) already created to track
 - [Andrey Velichkevich] Decrease the Feature Freeze timeline
   - [kimonas] We can move the Manifests Testing to the second week in the Feature Freeze phase
   - [kimonas] Lets also write down the main criteria for reducing feature freeze:
@@ -76,7 +83,7 @@ The release team will go over the provided feedback on Monday, November 8th, pro
   - [Anna] Let’s also ensure we ask new members if they would like to lead following releases
   - [Kimonas] Let’s think about removing one of the Release Team member or Shadow roles
 - [Anna Jung] Add release candidates to the timeline
-  - Lets add this information in the tables in the [timeline](https://github.com/kubeflow/manifests/tree/master/docs/releases/release-1.4#timeline) and [handbook](https://github.com/kubeflow/manifests/blob/master/docs/releases/handbook.md#timeline) 
+  - Lets add this information in the tables in the [timeline](https://github.com/kubeflow/manifests/tree/master/docs/releases/release-1.4#timeline) and [handbook](https://github.com/kubeflow/manifests/blob/master/docs/releases/handbook.md#timeline)
 - Move release docs to community rep? [Anna Jung]
   - **[Action Item]** Create an issue to move the kubeflow/manifests/docs/releases folder under kubeflow/community
-  - [Kimonas] Let’s ensure that the OWNERS file will include the release team to allow us to keep on iterating fast 
+  - [Kimonas] Let’s ensure that the OWNERS file will include the release team to allow us to keep on iterating fast


### PR DESCRIPTION
Adding the links to the retros.

I also slightly re-organized the structure by adding `Part 1` and `Part 2` sections to make it more clear what was discussed on each meeting.

/cc @annajung @jbottum @shannonbradshaw 