### PR TITLE
release: Add release team for 1.5

### DIFF
--- a/releases/release-1.5/release-team.md
+++ b/releases/release-1.5/release-team.md
@@ -3,7 +3,7 @@
 | **Role** | **Name** (**GitHub / Slack ID**) |
 |----------|----------------------------------|
 | Release Manager | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`) |
-| Release Team Member(s) | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`) |
+| Release Team Member(s) | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`), Daniela Plascencia (GitHub: [@DnPlas](https://github.com/DnPlas) / Slack: `@DnPlas`), Dominik Fleischmann (GitHub: [@DomFleischmann](https://github.com/DomFleischmann) / Slack: `Dominik Fleischmann`), Kylie Travis (GitHub: [@Bhakti087](https://github.com/Bhakti087) / Slack: `Kylie Travis`), Mathew Wicks (GitHub: [@thesuperzapper](https://github.com/thesuperzapper) / Slack: `Mathew Wicks`), Suraj Kota (GitHub: [@surajkota](https://github.com/surajkota) / Slack: `Suraj Kota`), Vedant Padwal (GitHub: [@js-ts](https://github.com/js-ts) / Slack: `Vedant Padwal`)|
 | Product Manager | Josh Bottum (GitHub: [@jbottum](https://github.com/jbottum) / Slack: `@JoshBottum`) |
 | Docs Lead | Shannon Bradshaw (GitHub: [@shannonbradshaw](https://github.com/shannonbradshaw) / Slack: `@Shannon Bradshaw`) |
 | Working Group Liaison(s) | |


### PR DESCRIPTION
After the outreach via the [mailing-list](https://groups.google.com/g/kubeflow-discuss/c/KDTXp49Mk48) , with today as the deadline, and our sync in the release team meeting of [12/6/2021](https://groups.google.com/g/kubeflow-discuss/c/u9r1Ij8PjuU) I'm making the PR to finalize the members of the team in GH. A follow up then will be to add everyone in the GH team https://github.com/kubeflow/internal-acls/pull/511.

NOTE: I'm adding everyone as a member for now, but we'll send another PR once we move forward with our discussion on merging the `Release Team Member` and `Shadow` roles respectively.

Could I also have an explicit /lgtm comment from everyone in the team before merging? This is your last chance to escape :-)
@annajung @DomFleischmann @DnPlas @jbottum @Bhakti087 @thesuperzapper @surajkota @js-ts 

cc @kubeflow/project-steering-group 