### PR TITLE
Add WG liaisons to 1.5 release team

### DIFF
--- a/releases/release-1.5/release-team.md
+++ b/releases/release-1.5/release-team.md
@@ -6,8 +6,16 @@
 | Release Team Member(s) | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`), Daniela Plascencia (GitHub: [@DnPlas](https://github.com/DnPlas) / Slack: `@DnPlas`), Dominik Fleischmann (GitHub: [@DomFleischmann](https://github.com/DomFleischmann) / Slack: `Dominik Fleischmann`), Kylie Travis (GitHub: [@Bhakti087](https://github.com/Bhakti087) / Slack: `Kylie Travis`), Mathew Wicks (GitHub: [@thesuperzapper](https://github.com/thesuperzapper) / Slack: `Mathew Wicks`), Suraj Kota (GitHub: [@surajkota](https://github.com/surajkota) / Slack: `Suraj Kota`), Vedant Padwal (GitHub: [@js-ts](https://github.com/js-ts) / Slack: `Vedant Padwal`)|
 | Product Manager | Josh Bottum (GitHub: [@jbottum](https://github.com/jbottum) / Slack: `@JoshBottum`) |
 | Docs Lead | Shannon Bradshaw (GitHub: [@shannonbradshaw](https://github.com/shannonbradshaw) / Slack: `@Shannon Bradshaw`) |
-| Working Group Liaison(s) | |
-| Distribution Representative |  |
+
+| **Working Group** | **Liaison(s)** (**GitHub / Slack ID**) |
+| ------------------|----------------------------------------|
+| AutoML | Andrey Velichkevich (GitHub: [@andreyvelich](https://github.com/andreyvelich) / Slack: `@Andrey Velichkevich`) |
+| Notebooks | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`) |
+| Manifests | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`) |
+| Pipelines | James Liu (GitHub: [@zijianjoy](https://github.com/zijianjoy) / Slack: `@James Liu`) |
+| Training | Jiaxin Shan (GitHub: [@Jeffwan](https://github.com/Jeffwan) / Slack: `@Jiaxin Shan`) |
+| Serving | Dan Sun (GitHub: [@yuzisun](https://github.com/yuzisun) / Slack `@dsun`) |
+
 
 - The definition of the release team roles and responsibilities can be found at [release handbook](../handbook.md)
 - The timeline for the release can be found at [release-1.5 documentation](README.md)


### PR DESCRIPTION
To further improve the release team's communication effectiveness we will define WG liaisons. We will also be pinging liaisons to ensure WGs end up getting release updates.

This was triggered by https://github.com/kubeflow/manifests/issues/2084#issuecomment-1000539950

We also have a checkbox for picking up liaisons early on in the release, but didn't ensure this was checked https://github.com/kubeflow/community/blob/master/releases/handbook.md#preparation. 

Getting better step by step. We will ensure the liaisons are written down early on in the next release

cc @DomFleischmann