### PR TITLE
Update the KF 1.5 timeline for 2 weeks

### DIFF
--- a/releases/release-1.5/README.md
+++ b/releases/release-1.5/README.md
@@ -16,35 +16,35 @@
 
 The 1.5 release cycle is proposed as follows
 
-- **Thursday, Oct 21st 2021**: Week 1 - Release Cycle Begins
-- **Thursday, Jan 13th 2021**: Week 13 - Feature Freeze
-- **Thursday, Jan 27th 2021**: Week 15 - Manifests Testing Starts
-- **Thursday, Feb 3rd 2021**: Week 16 - Manifests Testing Ends
-- **Thursday, Feb 3rd 2021**: Week 16 - Docs Update Ends
-- **Friday, Feb 4th 2021**: Week 16 - Distribution Testing Starts
-- **Wednesday, Feb 23rd 2021**: Week 19 - Distribution Testing Ends
-- **Thursday, Feb 24th 2021**: Week 19 - Kubeflow v1.5 Released
+- **Thursday, Oct 21st 2022**: Week 1 - Release Cycle Begins
+- **Wednesday, Jan 26th 2022**: Week 15 - Feature Freeze
+- **Wednesday, Feb 9th 2022**: Week 17 - Manifests Testing Starts
+- **Tuesday, Feb 15th 2022**: Week 18 - Manifests Testing Ends
+- **Tuesday, Feb 15th 2022**: Week 18 - Docs Update Ends
+- **Wednesday, Feb 16th 2022**: Week 18 - Distribution Testing Starts
+- **Tuesday, Mar 8th 2022**: Week 21 - Distribution Testing Ends
+- **Wednesday, Mar 9th 2022**: Week 21 - Kubeflow v1.5 Released
 
 ## Timeline
 
 | **When** | **Week** | **Who** | **What** |
 | -------- | -------- | ------- | -------- |
-| Mon Oct 11th 2021 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
-| Thu Oct 21st 2021 | Week 1 | Release Manager | Start of Release Cycle |
-| Thu Oct 21st 2021 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
-| Thu Jan 13th 2021 | Week 13 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
-| Thu Jan 13th 2021 | Week 13 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
-| Thu Jan 13th 2021 | Week 13 | Docs Lead | [Documentation](../handbook.md#documentation) |
-| Thu Jan 27th 2021 | Week 15 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Thu Jan 27th 2021 | Week 15 | Release Team | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| Thu Feb 3rd 2021 | Week 16 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| Thu Feb 3rd 2021 | Week 16 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Thu Feb 3rd 2021 | Week 16 | Manifest WG | [v1.5-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
-| Fri Feb 4th 2021 | Week 16 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Feb 23rd 2021 | Week 19 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Feb 23rd 2021 | Week 19 | Manifest WG | (optional) [v1.5-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
-| Thu Feb 24th 2021 | Week 19 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
-| Thu Feb 24th 2021 | Week 19 | Release Team | Publish Release Blog |
+| Mon Oct 11th 2022 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
+| Thu Oct 21st 2022 | Week 1 | Release Manager | Start of Release Cycle |
+| Thu Oct 21st 2022 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| Wed Jan 26th 2022 | Week 15 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jan 26th 2022 | Week 15 | Manifest WG | [v1.5-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jan 26th 2022 | Week 15 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Wed Feb 9th 2022 | Week 17 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Feb 9th 2022 | Week 17 | Release Team | [v1.5-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Tue Feb 15th 2022 | Week 18 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Tue Feb 15th 2022 | Week 18 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Tue Feb 15th 2022 | Week 18 | Manifest WG | [v1.5-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Feb 16th 2022 | Week 18 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Tue Mar 8th 2022 | Week 21 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Tue Mar 8th 2022 | Week 21 | Manifest WG | (optional) [v1.5-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Wed Mar 9th 2022 | Week 21 | Release Team | **v1.5** [Release Day](../handbook.md/#release) |
+| Wed Mar 9th 2022 | Week 21 | Release Team | Publish Release Blog |
 | TBD | TBD | Community | Release Retrospective |
 
 ## Phases


### PR DESCRIPTION
Follow up from https://github.com/kubeflow/manifests/issues/2098 and the release team meeting on [1/10/2022](https://docs.google.com/document/d/1Cs9XYl_SHfGP9vs1eHyqb6JAcpE3ilM-5iRuBnV9AB4/edit#heading=h.ebka1tmw12np) we will be delaying the release timeline for 2 weeks.

This means the Feature Freeze phase will start on Jan 26th (day after CM) and the final release will happen on March 9th.

/cc @annajung @jbottum @shannonbradshaw 
cc @DomFleischmann @DnPlas @js-ts @thesuperzapper @zijianjoy @andreyvelich @Jeffwan