### PR TITLE
Introduce common templates for the release

### DIFF
--- a/releases/templates/README.md
+++ b/releases/templates/README.md
@@ -1,0 +1,13 @@
+# Templates
+
+This directory contains the templates a release team member might need
+throughout the release.
+
+## notes
+
+After each release meeting a release team member should send an email to the
+mailing list, to give an update about the discussed items.
+
+The goal of this email is to contain an overview of the discussion points and
+decision that were maid. This way people can be up to date with the progress of
+these meetings, even if they can't participate

--- a/releases/templates/README.md
+++ b/releases/templates/README.md
@@ -5,9 +5,6 @@ throughout the release.
 
 ## notes
 
-After each release meeting a release team member should send an email to the
-mailing list, to give an update about the discussed items.
+After each release meeting, a release team member should email the [kubeflow-discuss mailing list](https://groups.google.com/u/1/g/kubeflow-discuss) to update the community about the discussed items.
 
-The goal of this email is to contain an overview of the discussion points and
-decision that were maid. This way people can be up to date with the progress of
-these meetings, even if they can't participate
+This email aims to contain an overview of the discussion points and decisions made during the meeting. This way, people can be up to date with the progress of these meetings even if they can't participate.

--- a/releases/templates/README.md
+++ b/releases/templates/README.md
@@ -3,7 +3,7 @@
 This directory contains the templates a release team member might need
 throughout the release.
 
-## notes
+## [notes](releases/templates/notes.txt)
 
 After each release meeting, a release team member should email the [kubeflow-discuss mailing list](https://groups.google.com/u/1/g/kubeflow-discuss) to update the community about the discussed items.
 

--- a/releases/templates/notes.txt
+++ b/releases/templates/notes.txt
@@ -6,7 +6,7 @@ Hello everyone, here are the notes and highlights from today's Release team call
 * Decision B
 
 Attendees:
-* A
+* Name
 
 Here are also some links for anyone that would like to get involved with the release team. You'll also need to join the kubeflow-discuss mailing list to get access to them.
 

--- a/releases/templates/notes.txt
+++ b/releases/templates/notes.txt
@@ -1,0 +1,20 @@
+[NOTES] Release team meeting {month}/{day}/{year}
+
+Hello everyone, here are the notes and highlights from today's Release team call. This is only an overview of the discussed items. If you'd like more info feel free to take a look at our notes and recording.
+
+* Topic A
+* Decision B
+
+Attendees:
+* A
+
+Here are also some links for anyone that would like to get involved with the release team. You'll also need to join the kubeflow-discuss mailing list to get access to them.
+
+Handbook: https://github.com/kubeflow/community/blob/master/releases/handbook.md
+Calendar invite: arrik.to/kf-release-team-cal
+Meeting Notes: arrik.to/kf-release-team-notes
+Recordings: arrik.to/kf-release-team-recordings
+Meet Room: arrik.to/kf-release-team-meet
+GDrive: arrik.to/kf-release-team-drive
+
+{name}, on behalf of the Release Team


### PR DESCRIPTION
Adding a `templates` folder to start keep tracking common templates we are using throughout the release.

I have a template for sending the notes to the mailing list, which we can commit to GH as well.

cc @kubeflow/release-team @akgraner