### PR TITLE
Add 1.6 release timeline

### DIFF
--- a/releases/release-1.6/README.md
+++ b/releases/release-1.6/README.md
@@ -1,0 +1,52 @@
+# Kubeflow 1.6
+
+### Links
+
+- [Release Team](release-team.md)
+- [Calendar](https://arrik.to/kf-release-team-cal)
+- [Meeting Notes](https://arrik.to/kf-release-team-notes)
+- [Recordings](https://arrik.to/kf-release-team-recordings)
+- [Retrospective Document](https://bit.ly/kf-release-1-6-retro)
+- Project Board
+- Contact
+  - [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) on slack
+  - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
+
+### TL;DR
+
+The 1.6 release cycle is proposed as follows
+
+- **Wednesday, Mar 16th 2022**: Week 1 - Release Cycle Begins
+- **Wednesday, Jun 1st 2022**: Week 12 - Feature Freeze
+- **Wednesday, Jun 15th 2022**: Week 14 - Manifests Testing Starts
+- **Wednesday, Jun 22nd 2022**: Week 15 - Manifests Testing Ends
+- **Wednesday, Jun 22nd 2022**: Week 15 - Docs Update Ends
+- **Wednesday, Jun 22nd 2022**: Week 15 - Distribution Testing Starts
+- **Wednesday, Jul 13th 2022**: Week 18 - Distribution Testing Ends
+- **Wednesday, Jul 20th 2022**: Week 19 - Kubeflow v1.6 Released
+
+## Timeline
+
+| **When** | **Week** | **Who** | **What** |
+| -------- | -------- | ------- | -------- |
+| Wed Mar 9th 2022 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
+| Wed Mar 16th 2022 | Week 1 | Release Manager | Start of Release Cycle |
+| Wed Mar 16th 2022 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| Wed Jun 1st 2022 | Week 12 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 1st 2022 | Week 12 | Manifest WG | [v1.6-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 1st 2022 | Week 12 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Wed Jun 15th 2022 | Week 14 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jun 15th 2022 | Week 14 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 22nd 2022 | Week 15 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Wed Jun 22nd 2022 | Week 15 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jun 22nd 2022 | Week 15 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 22nd 2022 | Week 15 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 13th 2022 | Week 18 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 13th 2022 | Week 18 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 20th 2022 | Week 19 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
+| Wed Jul 20th 2022 | Week 19 | Release Team | Publish Release Blog |
+| Mon Aug 1st 2022 | Week 21 | Release Team | Release Retrospective |
+
+## Phases
+
+Please refer to the [release handbook](../handbook.md)

--- a/releases/release-1.6/README.md
+++ b/releases/release-1.6/README.md
@@ -20,9 +20,9 @@ The 1.6 release cycle is proposed as follows
 - **Wednesday, Jun 1st 2022**: Week 12 - Feature Freeze
 - **Wednesday, Jun 15th 2022**: Week 14 - Manifests Testing Starts
 - **Wednesday, Jun 22nd 2022**: Week 15 - Manifests Testing Ends
-- **Wednesday, Jun 22nd 2022**: Week 15 - Docs Update Ends
 - **Wednesday, Jun 22nd 2022**: Week 15 - Distribution Testing Starts
 - **Wednesday, Jul 13th 2022**: Week 18 - Distribution Testing Ends
+- **Wednesday, Jul 13th 2022**: Week 18 - Docs Update Ends
 - **Wednesday, Jul 20th 2022**: Week 19 - Kubeflow v1.6 Released
 
 ## Timeline
@@ -37,12 +37,12 @@ The 1.6 release cycle is proposed as follows
 | Wed Jun 1st 2022 | Week 12 | Docs Lead | [Documentation](../handbook.md#documentation) |
 | Wed Jun 15th 2022 | Week 14 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
 | Wed Jun 15th 2022 | Week 14 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 22nd 2022 | Week 15 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
 | Wed Jun 22nd 2022 | Week 15 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
 | Wed Jun 22nd 2022 | Week 15 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
 | Wed Jun 22nd 2022 | Week 15 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
 | Wed Jul 13th 2022 | Week 18 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
 | Wed Jul 13th 2022 | Week 18 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 13th 2022 | Week 18 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
 | Wed Jul 20th 2022 | Week 19 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
 | Wed Jul 20th 2022 | Week 19 | Release Team | Publish Release Blog |
 | Mon Aug 1st 2022 | Week 21 | Release Team | Release Retrospective |


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Based on the 1.5 release date, March 10th, this is a proposed timeline for release 1.6.

Following the [17 week timeline](https://github.com/kubeflow/community/blob/master/releases/handbook.md#timeline), this PR proposes the following as the timeline for the 1.6 release:

- **Wednesday, Mar 16th, 2022**: Week 1 - Release Cycle Begins
- **Wednesday, Jun 1st, 2022**: Week 12 - Feature Freeze
- **Wednesday, Jun 15th, 2022**: Week 14 - Manifests Testing Starts
- **Wednesday, Jun 22nd, 2022**: Week 15 - Manifests Testing Ends
- ~**Wednesday, Jun 22nd, 2022**: Week 15 - Docs Update Ends~
- **Wednesday, Jun 22nd, 2022**: Week 15 - Distribution Testing Starts
- **Wednesday, Jul 13th, 2022**: Week 18 - Distribution Testing Ends
- ****Wednesday, Jul 13th, 2022**: Week 18 - Docs Update Ends**
- **Wednesday, Jul 20th, 2022**: Week 19 - Kubeflow v1.6 Released

As discussed during the April 11th release team meeting, due to the upcoming [KubeCon EU (May 16th - 20th)](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/), the proposal adds 2 weeks to the feature freeze deadline, pushing the release to 19 weeks instead of 17 weeks.

Please review and provide feedback by **April 25th, 2022 11:59 pm US Pacific Time**.

cc @kubeflow/release-team @kimwnasptd @kubeflow/wg-pipeline-leads @kubeflow/wg-manifests-leads @kubeflow/wg-notebooks-leads @kubeflow/wg-training-leads @kubeflow/wg-automl-leads @pvaneck @yuzisun @zijianjoy @jbottum 
