### PR TITLE
release: Add 1.6 release team

### DIFF
--- a/releases/release-1.6/release-team.md
+++ b/releases/release-1.6/release-team.md
@@ -1,0 +1,17 @@
+
+# Kubeflow 1.6 Release Team
+
+| **Role** | **Name** (**GitHub / Slack ID**) |
+|----------|----------------------------------|
+| Release Manager | Anna Jung (GitHub: [@annajung](https://github.com/annajung) / Slack: `@annajung`) |
+| Product Manager |  |
+| Docs Lead |  |
+| AutoML WG Liaison(s) | |
+| Notebooks WG Liaison(s) | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`)|
+| Manifests WG Liaison(s) | Kimonas Sotirchos (GitHub: [@kimwnasptd](https://github.com/kimwnasptd) / Slack: `@kimwnasptd`)|
+| Pipelines WG Liaison(s) | |
+| Training WG Liaison(s) | |
+| Distribution Representative |  |
+
+- The definition of the release team roles and responsibilities can be found at [release handbook](../handbook.md)
+- The timeline for the release can be found at [release-1.6 documentation](README.md)


### PR DESCRIPTION
Following the release of KF 1.5, let's use this issue to track the formation of the KF 1.6 release team.

After the discussion in the 1.5 [release retro](https://docs.google.com/document/d/1ck-WVk8_5Cbq8widXmjPCyTFZK5J6n2UaO8DTUGkiKc/edit?usp=sharing) and the progression of the last two releases we've decided to put more focus on distributing the release effort across the release team members. For this we will be focusing more on the WG liaison roles, so each team member will be assigned to a WG. 

Release team members will be responsible for joining the meetings of their assigned WGs and help with the communications with WGs across the release. Note that more than 1 member can be assigned to the same WG.

And with this, we'd like to **welcome everyone to participate in the 1.6 release team**! We are looking forward to new members joining the team and interacting with the WGs.

For the 3 lead roles we have currently converged on @annajung being the Release Manager of the KF 1.6 release team in:
* The last two release team meetings [`[1]`](https://docs.google.com/document/d/1Cs9XYl_SHfGP9vs1eHyqb6JAcpE3ilM-5iRuBnV9AB4/edit#heading=h.fbw1pq3vn39v) [`[2]`](https://docs.google.com/document/d/1Cs9XYl_SHfGP9vs1eHyqb6JAcpE3ilM-5iRuBnV9AB4/edit#heading=h.47gfrdnijf10)
* In the Community Meeting at 12/4/2022 (will add a link once it's out)

But if you'd be interested for one of the lead roles feel free to speak up as well! This way the current leads can evaluate more people and also assign shadows for these roles to cultivate the next leads.

You can take a look at the handbook in: https://github.com/kubeflow/community/blob/master/releases/handbook.md

cc @kubeflow/release-team @kubeflow/wg-pipeline-leads @kubeflow/wg-manifests-leads  @kubeflow/wg-notebooks-leads @kubeflow/wg-training-leads @kubeflow/wg-automl-leads @pvaneck @yuzisun @zijianjoy @jbottum