### PR TITLE
Update release timeline

### DIFF
--- a/releases/release-1.6/README.md
+++ b/releases/release-1.6/README.md
@@ -50,4 +50,3 @@ The 1.6 release cycle is proposed as follows
 ## Phases
 
 Please refer to the [release handbook](../handbook.md)
-d)

--- a/releases/release-1.6/README.md
+++ b/releases/release-1.6/README.md
@@ -17,13 +17,13 @@
 The 1.6 release cycle is proposed as follows
 
 - **Wednesday, Mar 16th 2022**: Week 1 - Release Cycle Begins
-- **Wednesday, Jun 1st 2022**: Week 12 - Feature Freeze
-- **Wednesday, Jun 15th 2022**: Week 14 - Manifests Testing Starts
-- **Wednesday, Jun 22nd 2022**: Week 15 - Manifests Testing Ends
-- **Wednesday, Jun 22nd 2022**: Week 15 - Distribution Testing Starts
-- **Wednesday, Jul 13th 2022**: Week 18 - Distribution Testing Ends
-- **Wednesday, Jul 13th 2022**: Week 18 - Docs Update Ends
-- **Wednesday, Jul 20th 2022**: Week 19 - Kubeflow v1.6 Released
+- **Wednesday, Jun 15th 2022**: Week 14 - Feature Freeze
+- **Wednesday, Jun 29th 2022**: Week 16 - Manifests Testing Starts
+- **Wednesday, Jul 6th 2022**: Week 17 - Manifests Testing Ends
+- **Wednesday, Jul 6th 2022**: Week 17 - Distribution Testing Starts
+- **Wednesday, Jul 27th 2022**: Week 20 - Distribution Testing Ends
+- **Wednesday, Jul 27th 2022**: Week 20 - Docs Update Ends
+- **Wednesday, Aug 3rd 2022**: Week 21 - Kubeflow v1.6 Released
 
 ## Timeline
 
@@ -32,21 +32,22 @@ The 1.6 release cycle is proposed as follows
 | Wed Mar 9th 2022 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
 | Wed Mar 16th 2022 | Week 1 | Release Manager | Start of Release Cycle |
 | Wed Mar 16th 2022 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
-| Wed Jun 1st 2022 | Week 12 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 1st 2022 | Week 12 | Manifest WG | [v1.6-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 1st 2022 | Week 12 | Docs Lead | [Documentation](../handbook.md#documentation) |
-| Wed Jun 15th 2022 | Week 14 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Wed Jun 15th 2022 | Week 14 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 22nd 2022 | Week 15 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Wed Jun 22nd 2022 | Week 15 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 22nd 2022 | Week 15 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 13th 2022 | Week 18 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 13th 2022 | Week 18 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 13th 2022 | Week 18 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| Wed Jul 20th 2022 | Week 19 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
-| Wed Jul 20th 2022 | Week 19 | Release Team | Publish Release Blog |
-| Mon Aug 1st 2022 | Week 21 | Release Team | Release Retrospective |
+| Wed Jun 15th 2022 | Week 14 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 15th 2022 | Week 14 | Manifest WG | [v1.6-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 15th 2022 | Week 14 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Wed Jun 29th 2022 | Week 16 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jun 29th 2022 | Week 16 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jul 6th 2022 | Week 17 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jul 6th 2022 | Week 17 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jul 6th 2022 | Week 17 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 27th 2022 | Week 20 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 27th 2022 | Week 20 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Wed Jul 27th 2022 | Week 20 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Wed Aug 3rd 2022 | Week 21 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
+| Wed Aug 3rd 2022 | Week 21 | Release Team | Publish Release Blog |
+| Mon Aug 15th 2022 | Week 23 | Release Team | Release Retrospective |
 
 ## Phases
 
 Please refer to the [release handbook](../handbook.md)
+d)


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

Due to the [current blocker for 1.6](https://github.com/kubeflow/testing/issues/1006), delaying the release for 2 weeks to give a WG and the Kubeflow community some time to come up with a solution.

The release date may be extended more until a solution is found for all affected WGs. 

cc @kubeflow/release-team 