### PR TITLE
Update the timeline again for another extension request

### DIFF
--- a/releases/release-1.6/README.md
+++ b/releases/release-1.6/README.md
@@ -17,13 +17,13 @@
 The 1.6 release cycle is proposed as follows
 
 - **Wednesday, Mar 16th 2022**: Week 1 - Release Cycle Begins
-- **Wednesday, Jun 15th 2022**: Week 14 - Feature Freeze
-- **Wednesday, Jun 29th 2022**: Week 16 - Manifests Testing Starts
-- **Wednesday, Jul 6th 2022**: Week 17 - Manifests Testing Ends
-- **Wednesday, Jul 6th 2022**: Week 17 - Distribution Testing Starts
-- **Wednesday, Jul 27th 2022**: Week 20 - Distribution Testing Ends
-- **Wednesday, Jul 27th 2022**: Week 20 - Docs Update Ends
-- **Wednesday, Aug 3rd 2022**: Week 21 - Kubeflow v1.6 Released
+- **Wednesday, Jun 29th 2022**: Week 16 - Feature Freeze
+- **Wednesday, Jul 13th 2022**: Week 18 - Manifests Testing Starts
+- **Wednesday, Jul 20th 2022**: Week 19 - Manifests Testing Ends
+- **Wednesday, Jul 20th 2022**: Week 19 - Distribution Testing Starts
+- **Wednesday, Aug 10th 2022**: Week 22 - Distribution Testing Ends
+- **Wednesday, Aug 10th 2022**: Week 22 - Docs Update Ends
+- **Wednesday, Aug 17th 2022**: Week 23 - Kubeflow v1.6 Released
 
 ## Timeline
 
@@ -32,20 +32,20 @@ The 1.6 release cycle is proposed as follows
 | Wed Mar 9th 2022 | Week 0 | Release Manager | [Preparation](../handbook.md#preparation) |
 | Wed Mar 16th 2022 | Week 1 | Release Manager | Start of Release Cycle |
 | Wed Mar 16th 2022 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
-| Wed Jun 15th 2022 | Week 14 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 15th 2022 | Week 14 | Manifest WG | [v1.6-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jun 15th 2022 | Week 14 | Docs Lead | [Documentation](../handbook.md#documentation) |
-| Wed Jun 29th 2022 | Week 16 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Wed Jun 29th 2022 | Week 16 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jul 6th 2022 | Week 17 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Wed Jul 6th 2022 | Week 17 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
-| Wed Jul 6th 2022 | Week 17 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 27th 2022 | Week 20 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 27th 2022 | Week 20 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
-| Wed Jul 27th 2022 | Week 20 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| Wed Aug 3rd 2022 | Week 21 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
-| Wed Aug 3rd 2022 | Week 21 | Release Team | Publish Release Blog |
-| Mon Aug 15th 2022 | Week 23 | Release Team | Release Retrospective |
+| Wed Jun 29th 2022 | Week 16 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 29th 2022 | Week 16 | Manifest WG | [v1.6-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jun 29th 2022 | Week 16 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Wed Jul 13th 2022 | Week 18 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jul 13th 2022 | Week 18 | Release Team | [v1.6-rc.1 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jul 20th 2022 | Week 19 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Wed Jul 20th 2022 | Week 19 | Manifest WG | [v1.6-rc.2 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Jul 20th 2022 | Week 19 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Aug 10th 2022 | Week 22 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Wed Aug 10th 2022 | Week 22 | Manifest WG | (optional) [v1.6-rc.3 Released](../handbook.md#distribution-testing-3-weeks) |
+| Wed Aug 10th 2022 | Week 22 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
+| Wed Aug 17th 2022 | Week 23 | Release Team | **v1.6** [Release Day](../handbook.md/#release) |
+| Wed Aug 17th 2022 | Week 23 | Release Team | Publish Release Blog |
+| Mon Aug 22nd 2022 | Week 24 | Release Team | Release Retrospective |
 
 ## Phases
 


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

After checking with WGs this week, some WG indicated they needed more time to get their features in for the 1.6 release.

Due to recent efforts spent by all WG to get their temporary solution running for the [testing infrastructure issue](https://github.com/kubeflow/testing/issues/1006), the release team decided to extend the release once more by extending the feature freeze and all upcoming deadlines by 2 weeks again.

This PR updates the release timeline with the following schedule:
- **Wednesday, Mar 16th 2022**: Week 1 - Release Cycle Begins
- **Wednesday, Jun 29th 2022**: Week 16 - Feature Freeze
- **Wednesday, Jul 13th 2022**: Week 18 - Manifests Testing Starts
- **Wednesday, Jul 20th 2022**: Week 19 - Manifests Testing Ends
- **Wednesday, Jul 20th 2022**: Week 19 - Distribution Testing Starts
- **Wednesday, Aug 10th 2022**: Week 22 - Distribution Testing Ends
- **Wednesday, Aug 10th 2022**: Week 22 - Docs Update Ends
- **Wednesday, Aug 17th 2022**: Week 23 - Kubeflow v1.6 Released

cc @kubeflow/release-team 