### PR TITLE
remove community meeting end-date & cleanup description

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -21,41 +21,43 @@
   date: 08/11/2020
   time: 5:30PM-6:25PM
   frequency: bi-weekly
-  until: 07/12/2022
-  video: https://us02web.zoom.us/j/83583392870?pwd=Q3lYQlAxbVYrdVZQNlp5cktIY2JmUT09
+  video: https://zoom.us/j/83583392870?pwd=Q3lYQlAxbVYrdVZQNlp5cktIY2JmUT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
     - |
       Notes & agenda: https://bit.ly/kf-meeting-notes
 
-      Join from PC, Mac, Linux, iOS or Android: https://us02web.zoom.us/j/83583392870?pwd=Q3lYQlAxbVYrdVZQNlp5cktIY2JmUT09
+      Join with Zoom: https://zoom.us/j/83583392870?pwd=Q3lYQlAxbVYrdVZQNlp5cktIY2JmUT09
       Meeting ID: 835 8339 2870
       Passcode: 499845
 
-      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656
-      International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
-  organizer: theadactyl
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+
+      Meeting Host Link: https://zoom.us/s/83583392870
+  organizer: autobot@kubeflow.org
 
 - id: kf032
   name: Kubeflow Community Call (US East/EMEA)
   date: 08/18/2020
   time: 8:00AM-8:55AM
   frequency: bi-weekly
-  until: 07/05/2022
-  video: https://us02web.zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
+  video: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
     - |
       Notes & agenda: https://bit.ly/kf-meeting-notes
 
-      Join from PC, Mac, Linux, iOS or Android: https://us02web.zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
+      Join with Zoom: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
       Meeting ID: 834 6990 5816
       Passcode: 683429
 
-      Join from phone in the US: +1 669 900 6833 or +1 646 558 8656
-      International numbers available: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+
+      Meeting Host Link: https://zoom.us/s/83469905816
   organizer: autobot@kubeflow.org
 
 - id: kf005


### PR DESCRIPTION
This PR fixes the community meeting invites (which have expired), by making them repeat forever.

It also updates the event description to:
- be more clear
- use the international zoom links
- provide the join link for hosts (the link will only work for designated meeting hosts)

__NOTE:__ we will need a calendar admin to run `calander_import.py` to update the calendar once we merge this PR.