### PR TITLE
add `Kubeflow Community Call (Europe/APAC)`

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -6,7 +6,8 @@
 #   the list).
 #   name - The name of the meeting.
 #   date - The date of the first meeting (month/day/year).
-#   time - The start and end of the meeting in PST time zone.
+#   time - The start and end of the meeting.
+#   timezone - The timezone in IANA Time Zone Database format (default: 'America/Los_Angeles').
 #   frequency - How often the meeting takes place.
 #   until - Optional the last day to repeat until
 #   attendees: See: https://developers.google.com/calendar/v3/reference/events/insert#python
@@ -16,12 +17,14 @@
 #   organizer - Github username of the meeting organizer.
 #
 
+# NOTE: this meeting is currently disabled
 - id: kf001
   name: Kubeflow Community Call (US West/APAC)
   date: 08/11/2020
   time: 5:30PM-6:25PM
   frequency: bi-weekly
   video: https://zoom.us/j/83583392870?pwd=Q3lYQlAxbVYrdVZQNlp5cktIY2JmUT09
+  until: 09/20/2022
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
@@ -36,6 +39,29 @@
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
       Meeting Host Link: https://zoom.us/s/83583392870
+  organizer: autobot@kubeflow.org
+
+- id: kf002
+  name: Kubeflow Community Call (Europe/APAC)
+  date: 10/04/2022
+  time: 8:00AM-8:55AM
+  timezone: Europe/London
+  frequency: bi-weekly
+  video: https://zoom.us/j/89752932714?pwd=bWRRcEY5MUM3S3U1TmY5NGZaL1ByUT09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & agenda: https://bit.ly/kf-meeting-notes
+
+      Join with Zoom: https://zoom.us/j/89752932714?pwd=bWRRcEY5MUM3S3U1TmY5NGZaL1ByUT09
+      Meeting ID: 897 5293 2714
+      Passcode: 055458
+
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+
+      Meeting Host Link: https://zoom.us/s/89752932714
   organizer: autobot@kubeflow.org
 
 - id: kf032

--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -41,7 +41,7 @@
       Meeting Host Link: https://zoom.us/s/83583392870
   organizer: autobot@kubeflow.org
 
-- id: kf002
+- id: kf033
   name: Kubeflow Community Call (Europe/APAC)
   date: 10/04/2022
   time: 8:00AM-8:55AM

--- a/calendar/calendar_import.py
+++ b/calendar/calendar_import.py
@@ -52,6 +52,7 @@ def update_meeting(service, meeting):
   day_of_week = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%A').upper()[0:2]
   start_datetime = datetime.strptime("{} {}".format(date, time_start), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
   end_datetime = datetime.strptime("{} {}".format(date, time_end), '%m/%d/%Y %I:%M%p').strftime('%Y-%m-%dT%H:%M:%S%z')
+  timezone = meeting.get("timezone", "America/Los_Angeles")
 
   event = {
     'summary': meeting['name'],
@@ -60,11 +61,11 @@ def update_meeting(service, meeting):
     'description': meeting['description'],
           'start': {
               'dateTime': start_datetime,
-              'timeZone': 'America/Los_Angeles',
+              'timeZone': timezone,
               },
             'end': {
               'dateTime': end_datetime,
-              'timeZone': 'America/Los_Angeles',
+              'timeZone': timezone,
               },
             'guestsCanSeeOtherGuests': 'false',
             'reminders': {


### PR DESCRIPTION
As discussed in the `Kubeflow Community Call (US West/APAC)` community meeting on 2022-09-20, due to low attendance, we will temporarily trial moving the `5:30pm San Fransisco` timeslot to `8:00am London` time.

This will result in the Kubeflow Community Meeting alternating weekly each Tuesday between `8:00am San Fransisco` and `8:00am London`.

__NOTE:__ the next call is still at `2022-09-27 @ 8:00am San Fransisco`, and the first meeting at the new time will be `2022-10-04 @ 8:00am London`

[kubeflow-discuss thread](https://groups.google.com/g/kubeflow-discuss/c/nxY_2FL1zes)