### PR TITLE
pause `8am London` community meeting

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -48,6 +48,7 @@
   timezone: Europe/London
   frequency: bi-weekly
   video: https://zoom.us/j/89752932714?pwd=bWRRcEY5MUM3S3U1TmY5NGZaL1ByUT09
+  until: 12/13/2022
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:


### PR DESCRIPTION
This PR pauses the 8am London Kubeflow Community Meeting.

__Reasons for this change:__

- The experiment of running a community meeting at 8am London was not able to get sufficient attendance of Kubeflow Community members ([Discussion Thread 1](https://groups.google.com/g/kubeflow-discuss/c/nxY_2FL1zes/m/WPCYZGh0AwAJ), [Discussion Thread 2](https://groups.google.com/g/kubeflow-discuss/c/PZo4Vw6yO-8))
- Reverting the meeting to its original time of 5:30pm PT would likely result in low attendance again (as was the case before the experiment)
- We now also have a meeting on the alternate Tuesday (at 8am PT) for the CNCF Transition, so this would leave us with 2 meetings on each Tuesday ([Discussion Thread 1](https://groups.google.com/g/kubeflow-discuss/c/lKcpcJPpd7c))

__Next Steps:__

- We will review how best to have an Aisa-accessible meeting after the new year
- We will keep the bi-weekly 8am PT community meeting unchanged