### PR TITLE
Add cncf-transition folder

### DIFF
--- a/cncf-transition/OWNERS
+++ b/cncf-transition/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - james-jwu
+  - theadactyl
+  - jbottum
+reviewers:
+  - james-jwu
+  - theadactyl
+  - jbottum

--- a/cncf-transition/README.md
+++ b/cncf-transition/README.md
@@ -1,0 +1,1 @@
+This folder contains files that will be used to support Kubeflow's [application](https://github.com/cncf/toc/pull/950) to become a CNCF incubation project. 


### PR DESCRIPTION
This folder will be used to host transition related files.