### PR TITLE
Simple update to versioning of Manifests/Notebooks

### DIFF
--- a/cncf-transition/versioning.md
+++ b/cncf-transition/versioning.md
@@ -14,3 +14,4 @@ For more details, see specification of working group version policy and release 
 - [Katib](https://github.com/kubeflow/katib/tree/master/docs/release#release-process)
 - [Pipelines](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#release-tags-and-branches)
 - [Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/release/releasing.md)
+- [Manifests and Notebooks](https://github.com/kubeflow/community/blob/master/releases/handbook.md#manifests-testing-1-week)

--- a/cncf-transition/versioning.md
+++ b/cncf-transition/versioning.md
@@ -14,4 +14,4 @@ For more details, see specification of working group version policy and release 
 - [Katib](https://github.com/kubeflow/katib/tree/master/docs/release#release-process)
 - [Pipelines](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#release-tags-and-branches)
 - [Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/release/releasing.md)
-- [Manifests and Notebooks](https://github.com/kubeflow/community/blob/master/releases/handbook.md#manifests-testing-1-week)
+- [Manifests and Notebooks](https://github.com/kubeflow/community/blob/master/releases/handbook.md#feature-freeze-2-weeks)


### PR DESCRIPTION
This is a simple documentation update to provide an explanation of the versioning process for the Manifests and Notebook Working Groups, which follow the general Kubeflow release process and is defined in the Kubeflow Release handbook.