### PR TITLE
Notebooks versioning policy

### DIFF
--- a/releases/handbook.md
+++ b/releases/handbook.md
@@ -227,6 +227,7 @@ From that phase and forward updates to the manifests repo must only be fixing co
 - Create a new **vX.Y-rc.0** tag that will be pointing to the branch created above
 - Add commits on top of the **vX.Y-branch** branch to include bug fixes. The other WGs can provide a new _git revision_ to Manifests WG leads. The new git revision must only include bug fixes, not new features.
 - On the last day of feature freeze, cut a new **vX.Y-rc.1** RC tag on the **vX.Y-branch** release branch.
+- Note - The Notebooks Working Group's versioning policy follows the Manifests Working Group's process.
 
 **Actions for the Release Team:**
 - Get a git revision from all WGs, on the first day of the Feature Freeze period. WGs need to have a git revision ready to give to the release team.


### PR DESCRIPTION
The purpose of this change is to provide documentation for Notebooks versioning policy.   The Notebooks versioning policy follows the Manifests policy as defined in this Kubeflow handbook.   This PR is related to the Kubeflow versioning policy overview which is being also being enhanced, https://github.com/kubeflow/community/pull/600/files#diff-6028d92dc4d1650e5ed145213adae7008214938b575f321242a09c178146b596