### PR TITLE
Add versioning policy reference for notebooks and manifest wg

### DIFF
--- a/cncf-transition/versioning.md
+++ b/cncf-transition/versioning.md
@@ -10,7 +10,7 @@ For pre-release artifacts, `rc` and a number incrementing from 0 are appended to
 In addition, some Kubeflow WGs leverage feature stages `alpha` and `beta` before releasing a stable version.
  For example, `X.Y.Z-alpha.0`.
 
-For more details, see specification of working group version policy and release process
+For more details, please refer to working groups' versioning policies and release processes:
 - [Katib](https://github.com/kubeflow/katib/tree/master/docs/release#release-process)
 - [Manifests](https://github.com/kubeflow/manifests#release-process)
 - [Notebooks](https://github.com/kubeflow/kubeflow/tree/master/releasing#release-process)

--- a/cncf-transition/versioning.md
+++ b/cncf-transition/versioning.md
@@ -12,5 +12,7 @@ In addition, some Kubeflow WGs leverage feature stages `alpha` and `beta` before
 
 For more details, see specification of working group version policy and release process
 - [Katib](https://github.com/kubeflow/katib/tree/master/docs/release#release-process)
+- [Manifests](https://github.com/kubeflow/manifests#release-process)
+- [Notebooks](https://github.com/kubeflow/kubeflow/tree/master/releasing#release-process)
 - [Pipelines](https://github.com/kubeflow/pipelines/blob/master/RELEASE.md#release-tags-and-branches)
 - [Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/release/releasing.md)


### PR DESCRIPTION
Part of https://github.com/kubeflow/community/issues/594

First PR https://github.com/kubeflow/community/pull/597 merged without adding a reference to manifest and notebooks wgs due to missing doc. Since then, both Manifests and Notebooks docs have been modified to include their versioning policy info. 
- https://github.com/kubeflow/kubeflow/issues/6900
- https://github.com/kubeflow/manifests/issues/2358

This update includes links to versioning policies for the Manifests and notebooks WG

This should complete the documentation of the versioning policy effort

cc @jbottum @james-jwu @theadactyl