### PR TITLE
[kubeflow 1.8] docs: add 1.8 release timeline

### DIFF
--- a/releases/release-1.8/README.md
+++ b/releases/release-1.8/README.md
@@ -16,19 +16,15 @@
 
 The 1.8 release cycle is proposed as follows
 
-- **Friday, May 5th 2023**     : Week 0      - Release team is formed
-- **Monday, May 8th 2023**     : Week 1  C\* - Release cycle begins
-- **Friday, May 12th 2023**    : Week 1  C\* - Roadmaps are finalized
-- **Wednesday, Aug 16th 2023** : Week 15 C\* - Feature freeze
-- **Wednesday, Aug 21st 2023** : Week 16     - Manifests testing and bug fixing starts
-- **Friday, Sept 1st 2023**    : Week 17 C\* - Manifests testing and bug fixing ends
-- **Monday, Sept 4th 2023**    : Week 18     - Docs update starts
-- **Monday, Sept 4th 2023**    : Week 18     - Distribution testing starts
-- **Friday, Sept 22nd 2023**   : Week 20     - Distribution testing ends
-- **Monday, Sept 25th 2023**   : Week 21 C\* - Pre-release bug fixing stage starts
-- **Friday, Oct 6th 2023**     : Week 22     - Pre-release bug fixing stage ends
-- **Friday, Oct 6th 2023**     : Week 22     - Docs update ends
-- **Wednesday, Oct 11th 2023** : Week 23 C\* - Kubeflow v1.8 Released
+- **Monday, May 1st 2023**      : Week 0  C\* - Release team is formed
+- **Wednesday, May 10th 2023**  : Week 1  C\* - Release cycle begins
+- **Monday, May 15th 2023**     : Week 2      - Roadmaps are finalised
+- **Wednesday, Aug 2nd 2023**   : Week 13 C\* - Feature freeze, manifests sync starts, docs update starts
+- **Wednesday, Aug 9th 2023**   : Week 14     - Manifests sync ends, manifests testing and bug fixing starts
+- **Wednesday, Aug 23rd 2023**  : Week 16     - Manifests testing and bug fixing ends, RC.0 is cut, distribution testing starts
+- **Wednesday, Sept 13th 2023** : Week 19 C\* - Distribution testing ends, pre-release bug fixing stage starts
+- **Wednesday, Sept 27th 2023** : Week 21 C\* - Pre-release bug fixing stage ends, docs update ends
+- **Wednesday, Oct 4th 2023**   : Week 22     - Kubeflow v1.8 Released
 
 >C\*: this week coincides with the Community Meeting
 

--- a/releases/release-1.8/README.md
+++ b/releases/release-1.8/README.md
@@ -1,0 +1,43 @@
+# Kubeflow 1.8
+
+### Links
+
+- [Release Team](release-team.md)
+- [Calendar](https://arrik.to/kf-release-team-cal)
+- [Meeting Notes](https://arrik.to/kf-release-team-notes)
+- [Recordings](https://arrik.to/kf-release-team-recordings)
+- [Retrospective Document](https://bit.ly/kf-release-1-6-retro)
+- Project Board
+- Contact
+  - [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) on slack
+  - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
+
+### TL;DR
+
+The 1.8 release cycle is proposed as follows
+
+- **Friday, May 5th 2023**     : Week 0      - Release team is formed
+- **Monday, May 8th 2023**     : Week 1  C\* - Release cycle begins
+- **Friday, May 12th 2023**    : Week 1  C\* - Roadmaps are finalized
+- **Wednesday, Aug 16th 2023** : Week 15 C\* - Feature freeze
+- **Wednesday, Aug 21st 2023** : Week 16     - Manifests testing and bug fixing starts
+- **Friday, Sept 1st 2023**    : Week 17 C\* - Manifests testing and bug fixing ends
+- **Monday, Sept 4th 2023**    : Week 18     - Docs update starts
+- **Monday, Sept 4th 2023**    : Week 18     - Distribution testing starts
+- **Friday, Sept 22nd 2023**   : Week 20     - Distribution testing ends
+- **Monday, Sept 25th 2023**   : Week 21 C\* - Pre-release bug fixing stage starts
+- **Friday, Oct 6th 2023**     : Week 22     - Pre-release bug fixing stage ends
+- **Friday, Oct 6th 2023**     : Week 22     - Docs update ends
+- **Wednesday, Oct 11th 2023** : Week 23 C\* - Kubeflow v1.8 Released
+
+>C\*: this week coincides with the Community Meeting
+
+## Timeline
+
+TODO: upon agreement on the dates above
+| **When** | **Week** | **Who** | **What** |
+| -------- | -------- | ------- | -------- |
+
+## Phases
+
+Please refer to the [release handbook](../handbook.md)

--- a/releases/release-1.8/README.md
+++ b/releases/release-1.8/README.md
@@ -3,11 +3,10 @@
 ### Links
 
 - [Release Team](release-team.md)
-- [Calendar](https://arrik.to/kf-release-team-cal)
-- [Meeting Notes](https://arrik.to/kf-release-team-notes)
-- [Recordings](https://arrik.to/kf-release-team-recordings)
-- [Retrospective Document](https://bit.ly/kf-release-1-6-retro)
-- Project Board
+- Calendar TBD
+- [Meeting Notes](https://bit.ly/kf-release-team-notes)
+- Recordings TBD
+- [Project Board (Private)](https://github.com/orgs/kubeflow/projects/58)
 - Contact
   - [#release](https://app.slack.com/client/T7QLHSH6U/C9V2WT2KV) on slack
   - [@release-team](https://github.com/orgs/kubeflow/teams/release-team) on GitHub
@@ -23,7 +22,8 @@ The 1.8 release cycle is proposed as follows
 - **Wednesday, Aug 9th 2023**   : Week 14     - Manifests sync ends, manifests testing and bug fixing starts
 - **Wednesday, Aug 23rd 2023**  : Week 16     - Manifests testing and bug fixing ends, RC.0 is cut, distribution testing starts
 - **Wednesday, Sept 13th 2023** : Week 19 C\* - Distribution testing ends, pre-release bug fixing stage starts
-- **Wednesday, Sept 27th 2023** : Week 21 C\* - Pre-release bug fixing stage ends, docs update ends
+- **Wednesday, Sept 27th 2023** : Week 21 C\* - Pre-release bug fixing stage ends
+- **Tuesday, Oct 3rd 2023**     : Week 22     - Docs update ends
 - **Wednesday, Oct 4th 2023**   : Week 22     - Kubeflow v1.8 Released
 
 >C\*: this week coincides with the Community Meeting
@@ -33,7 +33,21 @@ The 1.8 release cycle is proposed as follows
 TODO: upon agreement on the dates above
 | **When** | **Week** | **Who** | **What** |
 | -------- | -------- | ------- | -------- |
-
-## Phases
-
-Please refer to the [release handbook](../handbook.md)
+| Mon May 1st 2023 | Week 0 | Release manager | [Preparation](../handbook.md#preparation) |
+| Wed May 10th 2023 | Week 1 | Release manager | Start of Release Cycle |
+| Wed May 10th 2023 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
+| Wed Aug 2nd 2023 | Week 13 | Release team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
+| Wed Aug 2nd 2023 | Week 13 | Release manager, WG leads | Manifests sync starts |
+| Wed Aug 2nd 2023 | Week 13 | Docs lead | Docs update starts |
+| Wed Aug 9th 2023 | Week 14 | Release manager, WG leads | Manifests sync ends |
+| Wed Aug 9th 2023 | Week 14 | Manifests WG | Manifests testing and bug fixing starts |
+| Wed Aug 23rd 2023| Week 16 | Manifests WG | Manifests testing and bug fixing ends |
+| Wed Aug 23rd 2023 | Week 16 | Release manager | [v1.8-rc.0 Released](../handbook.md#feature-freeze-2-weeks) |
+| Wed Aug 23rd 2023 | Week 16 | Distributions | Distribution testing starts |
+| Wed Sept 13th 2023 | Week 19 | Distributions | Distribution testing ends |
+| Wed Sept 13th 2023 | Week 19 | WGs | Pre-release bug fixing stage starts |
+| Wed Sept 27th 2023 | Week 21 | WGs | Pre-release bug fixing stage ends |
+| Wed Oct 3rd 2023 | Week 22 | Docs lead | Docs update ends |
+| Wed Oct 4th 2023 | Week 22 | Release team | **v1.8** Release day |
+| Wed Oct 4th 2023 | Week 22 | Release team, Docs lead | Publish release blog |
+| Mon Oct 9th 2023 | Week 23 | Release team | Release retrospective |


### PR DESCRIPTION
Adding the release timeline for 1.8 release.

TODO:
- [x] Add table with details upon agreement on the timeline
- [x] Update links for meeting, calendar, project board, and meeting notes

cc @kubeflow/release-team @jbottum 