### PR TITLE
Add Adopters for Katib and Training Operator

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,48 @@
+# Adopters of Kubeflow Katib
+
+Below are the adopters of Kubeflow Katib. If you are using Katib
+please add yourself into the following list by a pull request.
+Please keep the list in alphabetical order.
+
+| Organization | Contact | Description of Use |
+| ------------ | ------- |------------------- |
+| [Akuity](https://akuity.io/) | [@terrytangyuan](https://github.com/terrytangyuan) |  |
+| [Ant Group](https://www.antgroup.com/) | [@ohmystack](https://github.com/ohmystack) | Automatic training in Ant Group internal AI Platform |
+| [babylon health](https://www.babylonhealth.com/) | [@jeremievallee](https://github.com/jeremievallee) | Hyperparameter tuning for AIR internal AI Platform |
+| [caicloud](https://caicloud.io/) | [@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
+| [canonical](https://ubuntu.com/) | [@RFMVasconcelos](https://github.com/rfmvasconcelos) | Hyperparameter tuning for customer projects in Defense and Fintech |
+| [CERN](https://home.cern/) | [@d-gol](https://github.com/d-gol) | Hyperparameter tuning within the ML platform on private cloud |
+| [cisco](https://cisco.com/) | [@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
+| [cubonacci](https://www.cubonacci.com) | [@janvdvegt](https://github.com/janvdvegt) | Hyperparameter tuning within the Cubonacci machine learning platform |
+| [CyberAgent](https://www.cyberagent.co.jp/en/) | [@tenzen-y](https://github.com/tenzen-y) | Experiment in CyberAgent internal ML Platform on Private Cloud |
+| [fuzhi](http://www.fuzhi.ai/) | [@planck0591](https://github.com/planck0591) | Experiment and Trial in AutoML Platform |
+| [karrot](https://uk.karrotmarket.com/) | [@muik](https://github.com/muik) | Hyperparameter tuning in Karrot ML Platform |
+
+# Adopters of Kubeflow Training Operator
+
+Below are the adopters of Kubeflow Training Operator. If you are using
+Training Operator please add yourself into the following list by a pull request.
+Please keep the list in alphabetical order.
+
+| Organization | Contact |
+| ------------ | ------- |
+| [Akuity](https://akuity.io/) | [Yuan Tang](https://github.com/terrytangyuan) |
+| [Alibaba Cloud](https://us.alibabacloud.com/) | [Yang Che](https://github.com/cheyang) |
+| [Alibaba DAMO Academy](https://damo.alibaba.com/) | [Yanjun Huang](https://damo.alibaba.com/about/) |
+| [Amazon Web Services](https://aws.amazon.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
+| [Ant Group](https://www.antgroup.com/) | [Yuan Tang](https://github.com/terrytangyuan) |
+| [Atrio](https://www.atrio.io/) | [César Gómez](https://github.com/cesargomez) |
+| [Bloomberg](https://www.bloomberg.com/) | [Chengjian Zheng](https://github.com/czheng94) and [Dan Sun](https://github.com/yuzisun) |
+| [Bytedance](https://www.bytedance.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
+| [Cisco](https://www.cisco.com/) | [Ramdoot Kumar](https://github.com/ramdootp) |
+| [Huawei](https://www.huawei.com/) | [Lei Su](https://github.com/suleisl2000) and [Fei Xu](https://github.com/fisherxu) |
+| [Iguazio](https://www.iguazio.com/) | [Yaron Haviv](https://github.com/yaronha) |
+| [Mellanox Technologies](https://www.mellanox.com/) | [Vitaliy Razinkov](https://github.com/vtlrazin) |
+| [NVIDIA](https://www.nvidia.com/) | [Rong Ou](https://github.com/rongou) |
+| [Pinduoduo](https://en.pinduoduo.com/) | [Shuwen Wang](https://github.com/antshuwen) |
+| [Polyaxon](https://polyaxon.com/) | [Mourad Mourafiq](https://github.com/mouradmourafiq) |
+| [Qihoo 360](https://www.360.cn/) | [Xigang Wang](https://github.com/xigang) |
+| [Qutoutiao](https://www.qutoutiao.net/) | [Zhaojing Yu](https://github.com/yuzhaojing) |
+| [Tencent](http://tencent.com/en-us/) | [Ce Gao](https://github.com/gaocegege), [Wang Zhang](https://github.com/zw0610) and [Lei Xue](https://github.com/carmark)  |
+| [TuSimple](https://www.tusimple.com/) | [Hengliang He](https://github.com/henglianghe) |
+| [vip](https://www.vip.com/) | [Harold Miao](https://github.com/oikomi) |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,48 +1,19 @@
-# Adopters of Kubeflow Katib
+# Adopters of Kubeflow Project
 
-Below are the adopters of Kubeflow Katib. If you are using Katib
-please add yourself into the following list by a pull request.
-Please keep the list in alphabetical order.
+Below are the adopters of Kubeflow. If you are using Kubeflow please add
+yourself into the following list by a pull request. Please keep the list in
+alphabetical order.
 
 | Organization | Contact | Description of Use |
-| ------------ | ------- |------------------- |
-| [Akuity](https://akuity.io/) | [@terrytangyuan](https://github.com/terrytangyuan) |  |
-| [Ant Group](https://www.antgroup.com/) | [@ohmystack](https://github.com/ohmystack) | Automatic training in Ant Group internal AI Platform |
-| [babylon health](https://www.babylonhealth.com/) | [@jeremievallee](https://github.com/jeremievallee) | Hyperparameter tuning for AIR internal AI Platform |
-| [caicloud](https://caicloud.io/) | [@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
-| [canonical](https://ubuntu.com/) | [@RFMVasconcelos](https://github.com/rfmvasconcelos) | Hyperparameter tuning for customer projects in Defense and Fintech |
-| [CERN](https://home.cern/) | [@d-gol](https://github.com/d-gol) | Hyperparameter tuning within the ML platform on private cloud |
-| [cisco](https://cisco.com/) | [@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
-| [cubonacci](https://www.cubonacci.com) | [@janvdvegt](https://github.com/janvdvegt) | Hyperparameter tuning within the Cubonacci machine learning platform |
-| [CyberAgent](https://www.cyberagent.co.jp/en/) | [@tenzen-y](https://github.com/tenzen-y) | Experiment in CyberAgent internal ML Platform on Private Cloud |
-| [fuzhi](http://www.fuzhi.ai/) | [@planck0591](https://github.com/planck0591) | Experiment and Trial in AutoML Platform |
-| [karrot](https://uk.karrotmarket.com/) | [@muik](https://github.com/muik) | Hyperparameter tuning in Karrot ML Platform |
+| ------------ | ------- | ------------------ |
+| TODO | TODO | TODO |
 
-# Adopters of Kubeflow Training Operator
+# Adopters of Individual Kubeflow Components
 
-Below are the adopters of Kubeflow Training Operator. If you are using
-Training Operator please add yourself into the following list by a pull request.
-Please keep the list in alphabetical order.
+Here is the list of adopters for various Kubeflow components. If you are using
+some of these Kubeflow components, please update the files by a pull request
+in the corresponding GitHub repositories.
 
-| Organization | Contact |
-| ------------ | ------- |
-| [Akuity](https://akuity.io/) | [Yuan Tang](https://github.com/terrytangyuan) |
-| [Alibaba Cloud](https://us.alibabacloud.com/) | [Yang Che](https://github.com/cheyang) |
-| [Alibaba DAMO Academy](https://damo.alibaba.com/) | [Yanjun Huang](https://damo.alibaba.com/about/) |
-| [Amazon Web Services](https://aws.amazon.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
-| [Ant Group](https://www.antgroup.com/) | [Yuan Tang](https://github.com/terrytangyuan) |
-| [Atrio](https://www.atrio.io/) | [César Gómez](https://github.com/cesargomez) |
-| [Bloomberg](https://www.bloomberg.com/) | [Chengjian Zheng](https://github.com/czheng94) and [Dan Sun](https://github.com/yuzisun) |
-| [Bytedance](https://www.bytedance.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
-| [Cisco](https://www.cisco.com/) | [Ramdoot Kumar](https://github.com/ramdootp) |
-| [Huawei](https://www.huawei.com/) | [Lei Su](https://github.com/suleisl2000) and [Fei Xu](https://github.com/fisherxu) |
-| [Iguazio](https://www.iguazio.com/) | [Yaron Haviv](https://github.com/yaronha) |
-| [Mellanox Technologies](https://www.mellanox.com/) | [Vitaliy Razinkov](https://github.com/vtlrazin) |
-| [NVIDIA](https://www.nvidia.com/) | [Rong Ou](https://github.com/rongou) |
-| [Pinduoduo](https://en.pinduoduo.com/) | [Shuwen Wang](https://github.com/antshuwen) |
-| [Polyaxon](https://polyaxon.com/) | [Mourad Mourafiq](https://github.com/mouradmourafiq) |
-| [Qihoo 360](https://www.360.cn/) | [Xigang Wang](https://github.com/xigang) |
-| [Qutoutiao](https://www.qutoutiao.net/) | [Zhaojing Yu](https://github.com/yuzhaojing) |
-| [Tencent](http://tencent.com/en-us/) | [Ce Gao](https://github.com/gaocegege), [Wang Zhang](https://github.com/zw0610) and [Lei Xue](https://github.com/carmark)  |
-| [TuSimple](https://www.tusimple.com/) | [Hengliang He](https://github.com/henglianghe) |
-| [vip](https://www.vip.com/) | [Harold Miao](https://github.com/oikomi) |
+- Adopters of [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md).
+
+- Adopters of [Kubeflow Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/adopters.md).


### PR DESCRIPTION
As we discussed during [Kubeflow to CNCF Transition Meeting](https://docs.google.com/document/d/1HXAl6ew5ZUgQaAnEHS1qEPxA5puUz2knUwXOZHU39sA/edit#), we want to add [Katib](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md) and [Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/adopters.md) Adopters list to the Community GitHub repo.

In the future, we should add more adopters in this doc (e.g. for Pipelines, Notebooks, etc.)

/assign @jbottum @akgraner @johnugeorge @annajung @zijianjoy @kimwnasptd 