### PR TITLE
clean up calendar and remove legacy meetings

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -1,23 +1,160 @@
-# This file lists all the meetings to be listed on the Kubeflow Community
-# Calendar (https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com).
-#
-# Required fields:
-#   id - A unique ID to give the meeting (add 1 to the previous meeting ID in
-#   the list).
-#   name - The name of the meeting.
-#   date - The date of the first meeting (month/day/year).
-#   time - The start and end of the meeting.
-#   timezone - The timezone in IANA Time Zone Database format (default: 'America/Los_Angeles').
-#   frequency - How often the meeting takes place.
-#   until - Optional the last day to repeat until
-#   attendees: See: https://developers.google.com/calendar/v3/reference/events/insert#python
-#   video - Zoom or Hangouts meeting link.
-#   description - Any other information about the meeting such
-#   as the meeting agenda link.
-#   organizer - Github username of the meeting organizer.
-#
+# This file controls the meetings on the "Kubeflow Community Calendar":
+# https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428@group.calendar.google.com
 
-# NOTE: this meeting is currently disabled
+# ==================================================================================================
+# Each list element is a map with the following keys:
+#   id:          a unique id for the meeting (TIP: increment the last id by 1)
+#   name:        name of the meeting
+#   date:        date of the first meeting "MM/dd/YYYY"
+#   time:        start and end time of the meeting "hour:minuteAM/PM-hour:minuteAM/PM"
+#   timezone:    timezone in IANA Time Zone Database format (default: 'America/Los_Angeles')
+#   frequency:   how often the meeting takes place (optional)
+#   until:       last date to repeat until "MM/dd/YYYY" (optional)
+#   attendees:   list of attendees (see: https://developers.google.com/calendar/v3/reference/events/insert#python)
+#   video:       a zoom or Hangouts meeting link
+#   description: the description of the meeting
+#   organizer:   the github username of the meeting organizer
+# ==================================================================================================
+
+# !!!!!!!!!!!!!!! IMPORTANT !!!!!!!!!!!!!!!
+# DO NOT REMOVE recurring meetings, set their `until` date in the past, and move them under "legacy meetings".
+# Otherwise, the meeting will remain in the calendar forever.
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+####################################################################################################
+# Current meetings
+####################################################################################################
+- id: kf032
+  name: Kubeflow Community Call (US East/EMEA)
+  date: 08/18/2020
+  time: 8:00AM-8:55AM
+  frequency: bi-weekly
+  video: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & agenda: https://bit.ly/kf-meeting-notes
+
+      Join with Zoom: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
+      Meeting ID: 834 6990 5816
+      Passcode: 683429
+
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+
+      Meeting Host Link: https://zoom.us/s/83469905816
+  organizer: autobot@kubeflow.org
+
+- id: kf025
+  name: Kubeflow Pipelines Community Meeting (PST PM)
+  date: 08/05/2020
+  time: 5:30pm-6:10pm
+  frequency: every-4-weeks
+  video: https://meet.google.com/jkr-dupp-wwm
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+    - email: kubeflow-pipelines@google.com
+  description:
+    - |
+      Notes & Agenda: http://bit.ly/kfp-meeting-notes
+      Join at: https://meet.google.com/jkr-dupp-wwm
+  organizer: chensun
+
+- id: kf026
+  name: Kubeflow Pipelines Community Meeting (PST AM)
+  date: 08/19/2020
+  time: 10:00am-10:40am
+  frequency: every-4-weeks
+  video: https://meet.google.com/jkr-dupp-wwm
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+    - email: kubeflow-pipelines@google.com
+  description:
+    - |
+      Notes & Agenda: http://bit.ly/kfp-meeting-notes
+      Join at: https://meet.google.com/jkr-dupp-wwm
+  organizer: chensun
+
+- id: kf034
+  name: Kubeflow Security Team Call (US West/APAC)
+  date: 02/15/2023
+  time: 8:00AM-9:00AM
+  frequency: bi-weekly
+  video: https://meet.google.com/rjj-axbq-vrp
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+    - email: akgraner@arrikto.com
+    - email: juliusvonkohout@gmail.com
+    - email: kimwnasptd@arrikto.com
+    - email: joshbottum@gmail.com
+  description:
+    - |
+      Notes & agenda: https://docs.google.com/document/d/1mRmtcZEnlVDKWUeQUYoogotq_FLkOaXLsIPIUN0JZ4I/edit?usp=sharing
+
+      Join with Google Meet: https://meet.google.com/rjj-axbq-vrp
+
+      Join with Phone (US) +1 234-218-2628 PIN: 234 621 560#
+      International numbers: https://tel.meet/rjj-axbq-vrp?pin=2231504127295
+
+      If you want to be manually added to the invite link, please reach out to Amber Graner (akgraner)
+  organizer: akgraner
+
+- id: kf035
+  name: Kubeflow Release Team Meeting (CET, US friendly)
+  date: 05/15/2023
+  time: 6:00PM-7:00PM
+  timezone: Europe/Madrid
+  frequency: weekly
+  video: https://meet.google.com/ezk-fmxo-fvu
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & agenda: https://bit.ly/kf-release-team-notes
+
+      Join with Google Meet: https://meet.google.com/ezk-fmxo-fvu
+      Time zone: Europe/Madrid
+      Video call link: https://meet.google.com/ezk-fmxo-fvu
+      Or dial: (ES) +34 877 99 40 20 PIN: 889 929 201#
+      More phone numbers: https://tel.meet/ezk-fmxo-fvu?pin=9345506892998
+  organizer: dnplas
+
+- id: kf036
+  name: Kubeflow Manifests WG Meeting
+  date: 06/01/2023
+  time: 6:00PM-7:00PM
+  timezone: Europe/Athens
+  frequency: bi-weekly
+  video: https://bit.ly/kf-wg-manifests-meet
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & Agenda: https://bit.ly/kf-wg-manifests-notes
+      Meeting Link: https://bit.ly/kf-wg-manifests-meet
+      Recordings: https://bit.ly/kf-wg-manifests-drive
+  organizer: kimwnasptd
+
+- id: kf037
+  name: Kubeflow Notebooks WG Meeting
+  date: 06/08/2023
+  time: 6:00PM-6:45PM
+  timezone: Europe/Athens
+  frequency: bi-weekly
+  video: https://bit.ly/kf-wg-notebooks-meet
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & Agenda: https://bit.ly/kf-wg-notebooks-notes
+      Meeting Link: https://bit.ly/kf-wg-notebooks-meet
+      Recordings: https://bit.ly/kf-wg-notebooks-drive
+  organizer: kimwnasptd
+
+####################################################################################################
+# Legacy meetings
+####################################################################################################
 - id: kf001
   name: Kubeflow Community Call (US West/APAC)
   date: 08/11/2020
@@ -63,28 +200,6 @@
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
       Meeting Host Link: https://zoom.us/s/89752932714
-  organizer: autobot@kubeflow.org
-
-- id: kf032
-  name: Kubeflow Community Call (US East/EMEA)
-  date: 08/18/2020
-  time: 8:00AM-8:55AM
-  frequency: bi-weekly
-  video: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & agenda: https://bit.ly/kf-meeting-notes
-
-      Join with Zoom: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
-      Meeting ID: 834 6990 5816
-      Passcode: 683429
-
-      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
-      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
-
-      Meeting Host Link: https://zoom.us/s/83469905816
   organizer: autobot@kubeflow.org
 
 - id: kf005
@@ -271,7 +386,6 @@
       https://sched.co/Uada
   organizer: jlewi
 
-
 - id: kf023
   name: "Book Signing for Oreilly's Kubeflow Operations Guide"
   date: 11/20/2019
@@ -281,42 +395,12 @@
       San Diego Convention Center – Sails Pavilion – O'Reilly Booth–S25
   organizer: jpatanooga
 
-
-- id: kf025
-  name: Kubeflow Pipelines Community Meeting (PST PM)
-  date: 08/05/2020
-  time: 5:30pm-6:10pm
-  frequency: every-4-weeks
-  video: https://meet.google.com/jkr-dupp-wwm
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-    - email: kubeflow-pipelines@google.com
-  description:
-    - |
-      Notes & Agenda: http://bit.ly/kfp-meeting-notes
-      Join at: https://meet.google.com/jkr-dupp-wwm
-  organizer: chensun
-
-- id: kf026
-  name: Kubeflow Pipelines Community Meeting (PST AM)
-  date: 08/19/2020
-  time: 10:00am-10:40am
-  frequency: every-4-weeks
-  video: https://meet.google.com/jkr-dupp-wwm
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-    - email: kubeflow-pipelines@google.com
-  description:
-    - |
-      Notes & Agenda: http://bit.ly/kfp-meeting-notes
-      Join at: https://meet.google.com/jkr-dupp-wwm
-  organizer: chensun
-
 - id: kf029
   name: Kubeflow Feature Store SIG Meeting (US/Asia friendly)
   date: 11/25/2020
   time: 6:00pm-6:30pm
   frequency: monthly
+  until: 07/01/2023
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
@@ -324,83 +408,3 @@
       Notes & Agenda: https://docs.google.com/document/d/1GHi-NFHmDA2TnH1pDrs4O7OyIQdZRtKatGAdedxte4w
       Zoom: Provided in meeting notes
   organizer: woop
-
-- id: kf034
-  name: Kubeflow Security Team Call (US West/APAC)
-  date: 02/15/2023
-  time: 8:00AM-9:00AM
-  frequency: bi-weekly
-  video: https://meet.google.com/rjj-axbq-vrp
-  until: 12/31/2023
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-    - email: akgraner@arrikto.com
-    - email: juliusvonkohout@gmail.com
-    - email: kimwnasptd@arrikto.com
-    - email: joshbottum@gmail.com
-  description:
-    - |
-      Notes & agenda: https://docs.google.com/document/d/1mRmtcZEnlVDKWUeQUYoogotq_FLkOaXLsIPIUN0JZ4I/edit?usp=sharing
-
-      Join with Google Meet: https://meet.google.com/rjj-axbq-vrp
-
-      Join with Phone (US) +1 234-218-2628 PIN: 234 621 560#
-      International numbers: https://tel.meet/rjj-axbq-vrp?pin=2231504127295
-
-      If you want to be manually added to the invite link, please reach out to Amber Graner (akgraner)
-
-  organizer: akgraner
-
-- id: kf035
-  name: Kubeflow Release Team Meeting (CET, US friendly)
-  date: 05/15/2023
-  time: 6:00PM-7:00PM
-  timezone: Europe/Madrid
-  frequency: weekly
-  video: https://meet.google.com/ezk-fmxo-fvu
-  until: 12/31/2023
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & agenda: https://bit.ly/kf-release-team-notes
-
-      Join with Google Meet: https://meet.google.com/ezk-fmxo-fvu
-      Time zone: Europe/Madrid
-      Video call link: https://meet.google.com/ezk-fmxo-fvu
-      Or dial: (ES) +34 877 99 40 20 PIN: 889 929 201#
-      More phone numbers: https://tel.meet/ezk-fmxo-fvu?pin=9345506892998
-  organizer: dnplas
-
-- id: kf036
-  name: Kubeflow Manifests WG Meeting
-  date: 06/01/2023
-  time: 6:00PM-7:00PM
-  timezone: Europe/Athens
-  frequency: bi-weekly
-  video: https://bit.ly/kf-wg-manifests-meet
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/kf-wg-manifests-notes
-      Meeting Link: https://bit.ly/kf-wg-manifests-meet
-      Recordings: https://bit.ly/kf-wg-manifests-drive
-  organizer: kimwnasptd
-
-- id: kf037
-  name: Kubeflow Notebooks WG Meeting
-  date: 06/08/2023
-  time: 6:00PM-6:45PM
-  timezone: Europe/Athens
-  frequency: bi-weekly
-  until: 12/31/2024
-  video: https://bit.ly/kf-wg-notebooks-meet
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/kf-wg-notebooks-notes
-      Meeting Link: https://bit.ly/kf-wg-notebooks-meet
-      Recordings: https://bit.ly/kf-wg-notebooks-drive
-  organizer: kimwnasptd


### PR DESCRIPTION
This PR resolves https://github.com/kubeflow/community/issues/630

It also makes it more clear which meetings are active and warns users not to remove recurring meetings from the file (as this leaves them in the calendar forever).