### PR TITLE
Add AutoML and Training WG Meeting to Kubeflow Calendar

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -152,6 +152,42 @@
       Recordings: https://bit.ly/kf-wg-notebooks-drive
   organizer: kimwnasptd
 
+- id: kf038
+  name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)
+  date: 09/20/2023
+  time: 11:00AM-12:00PM
+  timezone: Etc/UTC
+  frequency: every-4-weeks
+  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & Agenda: https://bit.ly/2PWVCkV
+
+      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+      Meeting ID: 839 443 5453
+      Passcode: R3ScM7
+  organizer: andreyvelich
+
+- id: kf039
+  name: Kubeflow AutoML and Training WG Meeting (US friendly)
+  date: 10/04/2023
+  time: 5:00PM-6:00PM
+  timezone: Etc/UTC
+  frequency: every-4-weeks
+  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & Agenda: https://bit.ly/2PWVCkV
+
+      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+      Meeting ID: 839 443 5453
+      Passcode: R3ScM7
+  organizer: andreyvelich
+
 ####################################################################################################
 # Legacy meetings
 ####################################################################################################


### PR DESCRIPTION
As we discussed during Kubeflow Community Call, I added AutoML and Training WG Call back to Kubeflow calendar.