### PR TITLE
Add maintainers doc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 The details of Kubeflow maintainers can be found in each working group specific repositories under the OWNERS file.
 
-- [Kubeflow](https://github.com/kubeflow/kubeflow/blob/master/OWNERS)
+- [Steering Committee](https://github.com/kubeflow/community/blob/master/proposals/STEERING-COMMITTEE.md)
 - [Katib](https://github.com/kubeflow/katib/blob/master/OWNERS)
 - [Manifests](https://github.com/kubeflow/manifests/blob/master/OWNERS)
 - [MPI Operator](https://github.com/kubeflow/mpi-operator/blob/master/OWNERS)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# Maintainers
+
+The details of Kubeflow maintainers can be found in each working group specific repositories under the OWNERS file.
+
+- [Kubeflow](https://github.com/kubeflow/kubeflow/blob/master/OWNERS)
+- [Katib](https://github.com/kubeflow/katib/blob/master/OWNERS)
+- [Manifests](https://github.com/kubeflow/manifests/blob/master/OWNERS)
+- [MPI Operator](https://github.com/kubeflow/mpi-operator/blob/master/OWNERS)
+- [Notebooks](https://github.com/kubeflow/kubeflow/blob/master/components/OWNERS)
+- [Pipelines](https://github.com/kubeflow/pipelines/blob/master/OWNERS)
+- [Pipelines on Tekton](https://github.com/kubeflow/kfp-tekton/blob/master/OWNERS)
+- [Training Operator](https://github.com/kubeflow/training-operator/blob/master/OWNERS)


### PR DESCRIPTION
WG leads are listed in OWNERS files in each repo. However, there isn't one place that references all the leads.

Part of https://github.com/cncf/toc/issues/1139,
> Create maintainer list + add to aggregated https://maintainers.cncf.io/ list by submitting a PR to it

This PR adds a MAINTAINERS md file that contains a reference to all the WG's OWNERS files and will be used in https://maintainers.cncf.io/ 

@zijianjoy @james-jwu 
