### PR TITLE
Update Notebooks WG meetings

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -137,20 +137,44 @@
   organizer: kimwnasptd
 
 - id: kf037
-  name: Kubeflow Notebooks WG Meeting
+  name: Kubeflow Notebooks WG Meeting (US + EMEA)
   date: 06/08/2023
-  time: 6:00PM-6:45PM
-  timezone: Europe/Athens
+  time: 8:00AM-8:55AM
   frequency: bi-weekly
-  video: https://bit.ly/kf-wg-notebooks-meet
+  video: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
     - |
-      Notes & Agenda: https://bit.ly/kf-wg-notebooks-notes
-      Meeting Link: https://bit.ly/kf-wg-notebooks-meet
-      Recordings: https://bit.ly/kf-wg-notebooks-drive
+      Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
+      
+      Join with Zoom: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
+      Meeting ID: 969 6799 6819
+      Passcode: 326059
+      
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: kimwnasptd
+
+- id: kf040
+  name: Kubeflow Notebooks WG Meeting (US + APAC)
+  date: 25/01/2024
+  time: 4:00PM-4:55PM
+  frequency: bi-weekly
+  video: https://zoom.us/j/95919259449?pwd=VGRNTm05VzRnZlIwN3lJRklsZmdqZz09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
+      
+      Join with Zoom: https://zoom.us/j/95919259449?pwd=VGRNTm05VzRnZlIwN3lJRklsZmdqZz09
+      Meeting ID: 959 1925 9449
+      Passcode: 066005
+      
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+  organizer: thesuperzapper
 
 - id: kf038
   name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)


### PR DESCRIPTION
__This PR updates the Notebooks WG meeting information:__

1. We have migrated to the new CNCF Zoom Account
2. We have added a new meeting (on the alternate week from the current 8:00AM meeting) on __Thursdays @ 4:00PM PT__ which is aimed at US + APAC attendees (but not attendable by EMEA)
3. We have moved to a doc for the meeting notes which lives on the Kubeflow Google Drive: [bit.ly/kf-notebooks-wg-notes](https://bit.ly/kf-notebooks-wg-notes)

__Why the change?__

- The reason we need to move to a weekly meeting is that we are working on Kubeflow Notebooks 2.0.
- Also, I want to note that the alternate Thursday @ 8:00AM time slot is taken by the Manifests WG meeting, so we cant use that. 
- If we have low attendance on the 4:00pm meeting, we will move it around based on demand, but for now we will start with 4:00PM.
- The CNCF Zoom will allow us to share hosting ability (rather than using the Google Meet of a specific company), and to automatically record the meeting (so it can be uploaded to YouTube)