### PR TITLE
Fix Notebooks WG meeting `date` format

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -158,7 +158,7 @@
 
 - id: kf040
   name: Kubeflow Notebooks WG Meeting (US + APAC)
-  date: 25/01/2024
+  date: 01/25/2024
   time: 4:00PM-4:55PM
   frequency: bi-weekly
   video: https://zoom.us/j/95919259449?pwd=VGRNTm05VzRnZlIwN3lJRklsZmdqZz09


### PR DESCRIPTION
Follow up from https://github.com/kubeflow/community/pull/689

I accidentally used the international date format, rather than the US one, so the calendar was not correctly updated for the Notebooks WG meeting.