### PR TITLE
Add Kubeflow TOC Charter

### DIFF
--- a/proposals/kubeflow-technical-oversight-committee.md
+++ b/proposals/kubeflow-technical-oversight-committee.md
@@ -129,7 +129,29 @@ Term End</th>
 
 ## Decision process
 
-The TOC desires to always reach consensus.
+The TOC desires to always reach consensus. The meetings for decision process should include:
+
+- Topics should be submitted in the form of a question, which can be voted on.
+
+- Topics can be prioritized by the meeting host.
+
+- Topics can be reviewed at the beginning of the meeting.
+
+- Topics should be addressed one at a time, unless there is a dependency that needs to be considered.
+
+- After stating the issue, the host should ask for a non-binding vote.
+
+- If there is consensus, then the host can ask for a 2nd to make the vote binding.
+
+- After the vote, any member can ask for a discussion period, which by default is ten minutes or less.
+
+- After discussion, the host will confirm consensus and/or ask for a vote.
+
+- The vote will be recorded.
+
+If member(s) abstain because they need more information, the issue will be documented with the
+additional information needed before it can be addressed as topic again in a future meeting.
+If the information is not provided within 2 weeks, a member can ask for a binding vote in the next meeting.
 
 ### Normal decision process
 

--- a/proposals/kubeflow-technical-oversight-committee.md
+++ b/proposals/kubeflow-technical-oversight-committee.md
@@ -10,7 +10,9 @@ community and project change.
 
 - Project direction and roadmap:
 
-  - Set the overall technical direction and Kubeflow roadmap.
+  - Consolidate together with WGs the overall technical direction and Kubeflow roadmap.
+
+  - Suggest cross-WGs features like LLMOps and work with stakeholders to address it.
 
   - Create proposals based on TOC discussions and bring them to the relevant working groups for discussion.
 
@@ -49,7 +51,7 @@ The committee currently recognizes this delegated authority for [To be set up]:
 
 - Kubeflow components guidance is delegated to the appropriate [Working Groups](../wgs/wg-governance.md).
 
-- Enforcing Kubeflow conformance program rules created by TOC and KSC is deleted to the\
+- Enforcing Kubeflow conformance program rules created by TOC and KSC is delegated to the
   [Conformance Committee](CONFORMANCE-COMMITTEE.md).
 
 ## Committee Meetings
@@ -75,6 +77,8 @@ feedback there.
 
 TOC is composed of 3 (three) members. They are elected according
 to the election policy [TODO: add link].
+No more than two seats may be held by employees of the same organization
+(or conglomerate, in the case of companies owning each other).
 Seats on the TOC are held by an individual, not by their employer.
 
 The current membership of the committee is (listed alphabetically by first name):

--- a/proposals/kubeflow-technical-oversight-committee.md
+++ b/proposals/kubeflow-technical-oversight-committee.md
@@ -1,0 +1,184 @@
+# Kubeflow Technical Oversight Committee
+
+The Kubeflow Technical Oversight Committee (TODO: TOC or KTOC ?) is responsible for
+cross-cutting product and design decisions.
+
+The governance of Kubeflow is an open, living document, and will continue to evolve as the
+community and project change.
+
+## Charter
+
+- Project direction and roadmap:
+
+  - Set the overall technical direction and Kubeflow roadmap.
+
+  - Create proposals based on TOC discussions and bring them to the relevant working groups for discussion.
+
+  - Working with working groups on Kubeflow cross-component integrations.
+
+  - Resolving issues that, despite best efforts, a working group has been unable to resolve.
+
+- Project releases, security, and stability:
+
+  - Ensure the stability of Kubeflow releases.
+
+  - Set the priorities of individual releases to ensure coherency and proper sequencing.
+
+  - Working together with Security WG to establish security guidelines to ensure Kubeflow follows
+    the CNCF security best practices.
+
+  - Advise the Conformance Committee on conformance rules and tests.
+
+- Project oversight and scope:
+
+  - Working together with Kubeflow Steering Committee (KSC) to establish guidelines for
+    Kubeflow distributions and third-party applications.
+
+  - Advise the KSC on creation and deletion Kubeflow working groups.
+
+  - Advise the KSC on accepting new Kubeflow components and archiving existing
+    Kubeflow components.
+
+  - Advise the KSC on changes for Kubeflow distributions and third-party applications.
+
+## Delegated Authority
+
+TOC may choose to delegate its authority to other committees as-needed.
+
+The committee currently recognizes this delegated authority for [To be set up]:
+
+- Kubeflow components guidance is delegated to the appropriate [Working Groups](../wgs/wg-governance.md).
+
+- Enforcing Kubeflow conformance program rules created by TOC and KSC is deleted to the\
+  [Conformance Committee](CONFORMANCE-COMMITTEE.md).
+
+## Committee Meetings
+
+TOC currently meets at least bi-weekly, or as-needed. Meetings are open to the public and held online,
+unless they pertain to sensitive or privileged matters. Examples of such matters are:
+
+- Private emails to the committee
+- Certain Escalations
+- Disputes between members
+- Security reports
+
+Meeting notes are available to members of the
+[kubeflow-discuss mailing](https://www.kubeflow.org/docs/about/community/#kubeflow-mailing-list)
+list, unless community member privacy requires otherwise.
+Public meetings will be recorded and the recordings made available publicly.
+
+Questions and proposals for changes to governance are posted as issues in the
+[kubeflow/community](https://github.com/kubeflow/community) repository, and the TOC invites community
+feedback there.
+
+## Committee members
+
+TOC is composed of 3 (three) members. They are elected according
+to the election policy [TODO: add link].
+Seats on the TOC are held by an individual, not by their employer.
+
+The current membership of the committee is (listed alphabetically by first name):
+
+<table>
+  <thead>
+    <tr>
+      <th><br>
+Member</th>
+      <th><br>
+Organization</th>
+      <th><br>
+Github Profile</th>
+      <th><br>
+Term Start</th>
+      <th><br>
+Term End</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>
+
+## Emeritus Committee Members
+
+[This section will be populated when there are retired committee members.]
+
+## Decision process
+
+The TOC desires to always reach consensus.
+
+### Normal decision process
+
+Decisions requiring a vote include:
+
+- Issuing written policy.
+- Amending existing written policy.
+- Creating, removing, or modifying a working group.
+- Accepting or removing Kubeflow components.
+- Official responses to publicly raised issues.
+- Any other decisions that at least half of the members (rounded down) present decide require a vote
+
+Decisions are made in meetings when a quorum of the members are present and may pass with at
+least half the members (rounded up) of the committee supporting it.
+
+Quorum is considered reached when at least half of the members (rounded up) are present.
+Members of TOC may abstain from a vote. Abstaining members will only be considered as
+contributing to quorum, in the event that a vote is called in a meeting.
+
+### Special decision process
+
+Issues that impact the TOC governance require a special decision process. Issues include:
+
+- Changes to the TOC charter
+- TOC voting rules
+
+The issue may pass with 70% of the members (rounded up) of the committee supporting it.
+
+### Results
+
+The results of the decision process are recorded and made publicly available,
+unless they pertain to sensitive or privileged matters. The results will include:
+
+- Description of the issue
+- Names of members who supported, opposed, and abstained from the vote.
+-
+
+## Getting in Touch
+
+There are two ways to raise issues to the steering committee for decision:
+
+1. Emailing the steering committee at [TODO: add email]. This is a private discussion list to which
+   all members of the committee have access.
+
+1. Open an issue in the [kubeflow/community](https://github.com/kubeflow/community) repository and
+   indicate that you would like attention from the TOC using GitHub label [TODO: add label].
+
+## Changes to the charter
+
+Changes to the TOC charter may be proposed via a PR on the charter itself. Amendments are accepted
+following the [Special Decision Process](#special-decision-process) detailed above.
+
+Kubeflow community members can propose changes and improvements to the existing TOC charter.
+
+Proposals and amendments to the charter are available for at least a period of one week for
+comments and questions before a vote will occur.


### PR DESCRIPTION
This is initial draft for the Kubeflow TOC charter. 
Here is the Google doc for the same proposal for folks who want to review it and don't use GitHub regularly: 
https://docs.google.com/document/d/1jskqTsqpuoC1Ed0HfitfSOk_k93RMYDkJPrIO7k0Veo/edit?usp=sharing

A few questions that I have:

- Should we name it TOC or KTOC ? In [this doc](https://github.com/kubeflow/community/blob/master/proposals/GOVERNANCE.md#kubeflow-technical-oversight-committee-ktoc) we name it as KTOC.

- Giving the comment that @juliusvonkohout raised on the last community call, what do we think about electing 3 members on the first year and 2 more members in the second year ? 
Also, we can think about relaxing rules to be nominated (e.g. 25 contributions rather than 50).

- I divided charter in 3 sections: Project direction and roadmap, Project releases, security, and stability, Project oversight and scope. Feel free to propose your ideas and comments.


I keep decision process and other parts of charter the same as for KSC.

We will start elections soon and @akgraner will provide updates.

/cc @kubeflow/wg-training-leads @kubeflow/wg-notebooks-leads @kubeflow/wg-pipeline-leads @kubeflow/wg-automl-leads @kubeflow/wg-manifests-leads @tenzen-y @kuizhiqing @kubeflow/release-team  @kubeflow/kubeflow-steering-committee @andreeamun @akgraner @tarilabs @bigsur0 @vara-bonthu @yuchaoran2011