### PR TITLE
Added DCO sign-off hook and updated info regarding the migration from CLA to DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ contributions to this project. Please read the
 
 The contributor's guide
 
-* shows you where to find the Contributor License Agreement (CLA) that you need 
-  to sign,
+* shows you where to find the Developer Certificate of Origin (DCO) that you need 
+  to agree to,
 * helps you get started with your first contribution to Kubeflow,
 * and describes the pull request and review workflow in detail, including the
   OWNERS files and automated workflow tool.

--- a/dco-signoff-hook/README.md
+++ b/dco-signoff-hook/README.md
@@ -1,6 +1,7 @@
 # Signing off commits
 
 To automatically sign off on every commit, copy the [prepare-commit-msg](prepare-commit-msg) file to the `.git/hooks` directory in your repo or if you already have such a hook, merge the contents into your existing hook.
+You can also configure it globally (for every repo on your machine) by copying the [prepare-commit-msg](prepare-commit-msg) file to the `${HOME}/.git-template/hooks` directory.
 
 You can also sign off your contributions manually by doing ONE of the following:
 * Use `git commit -s ...` with each commit to add the sign-off or

--- a/dco-signoff-hook/README.md
+++ b/dco-signoff-hook/README.md
@@ -1,0 +1,3 @@
+# Signing off commits
+
+To automatically sign off on every commit, copy the [prepare-commit-msg](prepare-commit-msg) file to the `.git/hooks` directory in your repo or if you already have such a hook, merge the contents into your existing hook.

--- a/dco-signoff-hook/README.md
+++ b/dco-signoff-hook/README.md
@@ -1,3 +1,7 @@
 # Signing off commits
 
 To automatically sign off on every commit, copy the [prepare-commit-msg](prepare-commit-msg) file to the `.git/hooks` directory in your repo or if you already have such a hook, merge the contents into your existing hook.
+
+You can also sign off your contributions manually by doing ONE of the following:
+* Use `git commit -s ...` with each commit to add the sign-off or
+* Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.

--- a/dco-signoff-hook/prepare-commit-msg
+++ b/dco-signoff-hook/prepare-commit-msg
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
The DCO sign-off hook was copied from [Argo Project](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal).