### PR TITLE
Change AutoML and Training WG call to 2pm UTC

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -147,11 +147,11 @@
   description:
     - |
       Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
-      
+
       Join with Zoom: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
       Meeting ID: 969 6799 6819
       Passcode: 326059
-      
+
       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: kimwnasptd
@@ -167,11 +167,11 @@
   description:
     - |
       Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
-      
+
       Join with Zoom: https://zoom.us/j/95919259449?pwd=VGRNTm05VzRnZlIwN3lJRklsZmdqZz09
       Meeting ID: 959 1925 9449
       Passcode: 066005
-      
+
       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
   organizer: thesuperzapper
@@ -196,7 +196,7 @@
 - id: kf038
   name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)
   date: 09/20/2023
-  time: 11:00AM-12:00PM
+  time: 2:00PM-3:00PM
   timezone: Etc/UTC
   frequency: every-4-weeks
   video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09


### PR DESCRIPTION
Based on our [recent community survey](https://docs.google.com/forms/d/1j6EAuap6U3WPV-Z3YHRNE_yywJ-GQUETatYBiYX0K-c/edit), we decided to move AutoML and Training WG Call to 2pm UTC.

/assign @kubeflow/wg-training-leads @kubeflow/kubeflow-steering-committee 