### PR TITLE
Migrate community call to CNCF Zoom

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -25,25 +25,25 @@
 # Current meetings
 ####################################################################################################
 - id: kf032
-  name: Kubeflow Community Call (US East/EMEA)
+  name: Kubeflow Community Call (US + EMEA)
   date: 08/18/2020
   time: 8:00AM-8:55AM
   frequency: weekly
-  video: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
+  video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
     - |
       Notes & agenda: https://bit.ly/kf-meeting-notes
 
-      Join with Zoom: https://zoom.us/j/83469905816?pwd=aWM5clpLOTNTMU9udFpkZmV0L01VQT09
-      Meeting ID: 834 6990 5816
-      Passcode: 683429
+      Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+      Meeting ID: 991 5242 7566
+      Passcode: 645928
 
       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
-      Meeting Host Link: https://zoom.us/s/83469905816
+      Meeting Host Link: https://zoom.us/s/99152427566
   organizer: autobot@kubeflow.org
 
 - id: kf025


### PR DESCRIPTION
This PR migrates from the community calls from my personal Zoom account to the CNCF Zoom account.

We share the host password for this new account using OnePassword.

We need to warn people that the link to join has changed.