### PR TITLE
Add Spark Operator Community Call

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -198,7 +198,7 @@
   date: 05/17/2024
   time: 10:00AM-11:00AM
   frequency: every-4-weeks
-  video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+  video: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:
@@ -207,9 +207,9 @@
 
       Notes & Agenda: https://docs.google.com/document/d/1AnG6ptKLBY7O6ddyNm4SVsEbfu6jiyVyN3hDDgDUnxQ/edit?usp=sharing
 
-      Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
-      Meeting ID: 991 5242 7566
-      Passcode: 645928
+      Join with Zoom: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
+      Meeting ID: 938 7060 2975
+      Passcode: 307820
 
       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH

--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -193,6 +193,29 @@
       Meeting notes: https://docs.google.com/document/d/1DmMhcae081SItH19gSqBpFtPfbkr9dFhSMCgs-JKzNo/edit?usp=sharing
   organizer: tarilabs
 
+- id: kf042
+  name: Kubeflow Spark Operator Community Call
+  date: 05/17/2024
+  time: 10:00AM-11:00AM
+  frequency: every-4-weeks
+  video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+  attendees:
+    - email: kubeflow-discuss@googlegroups.com
+  description:
+    - |
+      Monthly recurring meeting for Kubeflow Spark Operator.
+
+      Notes & Agenda: https://docs.google.com/document/d/1AnG6ptKLBY7O6ddyNm4SVsEbfu6jiyVyN3hDDgDUnxQ/edit?usp=sharing
+
+      Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+      Meeting ID: 991 5242 7566
+      Passcode: 645928
+
+      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+
+  organizer: vara-bonthu
+
 - id: kf038
   name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)
   date: 09/20/2023

--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -194,7 +194,7 @@
   organizer: tarilabs
 
 - id: kf042
-  name: Kubeflow Spark Operator Community Call
+  name: Kubeflow Spark Operator Meeting
   date: 05/17/2024
   time: 10:00AM-11:00AM
   frequency: every-4-weeks


### PR DESCRIPTION
I added Spark Operator community call.
The first meeting will be held on May 17th 2024.

@thesuperzapper @jbottum Should we use this Zoom link for CNCF Zoom account ?
```
https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
```
/hold for review
/assign @kubeflow/wg-data-leads 