### PR TITLE
docs: expand on DCO using manual sign-off

### DIFF
--- a/dco-signoff-hook/README.md
+++ b/dco-signoff-hook/README.md
@@ -5,7 +5,7 @@ You can also configure it globally (for every repo on your machine) by copying t
 
 You can also sign off your contributions manually by doing ONE of the following:
 * Use `git commit -s ...` with each commit to add the sign-off or
-* Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.
+* Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message; please note that Name and Email of sign-off must match the commit's Author, in other words the `user.name` and `user.email` of the git configuration used when creating the commit. Using `git commit -s ...` does this automatically.
 
 The email address must match your primary GitHub email. You do NOT need cryptographic (e.g. gpg) signing.
 * Use `git commit -s --amend ...` to add a sign-off to the latest commit, if you forgot.


### PR DESCRIPTION
@hbelmiro wdyt?
I had this gotchas when DCO didn't pass despite I've used the hook (in a project, the Name was different).

I'm also not sure the email of commit "must" match the github primary email, but that's for another time.