### PR TITLE
Add instructions for retroactively signing-off on multiple commits

### DIFF
--- a/dco-signoff-hook/README.md
+++ b/dco-signoff-hook/README.md
@@ -8,6 +8,7 @@ You can also sign off your contributions manually by doing ONE of the following:
 * Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.
 
 The email address must match your primary GitHub email. You do NOT need cryptographic (e.g. gpg) signing.
-* Use `git commit -s --amend ...` to add a sign-off to the latest commit, if you forgot.
+* Use `git commit -s --amend ...` to add a sign-off to the latest commit or
+* Use `git rebase HEAD~N --signoff` to sign-off on the last `N` commits, if you forgot.
 
 *Note*: Some projects will provide specific configuration to ensure all commits are signed-off. Please check the project's documentation for more details.


### PR DESCRIPTION
I forget, to sign off, and this command! Thought it would be helpful :)

<img width="1109" alt="Screenshot 2024-10-08 at 11 18 21 PM" src="https://github.com/user-attachments/assets/45971ac1-f7f4-45ca-b357-3001586ae7d7">
