### PR TITLE
Updated Spark Operator monthly catchup time to accommodate maintainers

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -137,7 +137,8 @@
 - id: kf042
   name: Kubeflow Spark Operator Meeting
   date: 05/17/2024
-  time: 10:00AM-11:00AM
+  time: 4:00PM-5:00PM
+  timezone: America/Los_Angeles
   frequency: every-4-weeks
   video: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
   attendees:

--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -136,9 +136,8 @@
 
 - id: kf042
   name: Kubeflow Spark Operator Meeting
-  date: 05/17/2024
+  date: 10/18/2024
   time: 4:00PM-5:00PM
-  timezone: America/Los_Angeles
   frequency: every-4-weeks
   video: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
   attendees:


### PR DESCRIPTION
This PR updates the time for the monthly Spark Operator catchup meeting to better accommodate maintainers from different time zones, specifically from Australia and China.

**Key changes:**

Adjusted the meeting time to ensure it aligns with more favorable working hours for maintainers/contributors in Australia and China. The updated meeting time aims to improve participation and collaboration across global maintainers.
