### PR TITLE
Introduce rule to allow 1 vote only from the same organization

### DIFF
--- a/KUBEFLOW-STEERING-COMMITTEE.md
+++ b/KUBEFLOW-STEERING-COMMITTEE.md
@@ -72,8 +72,11 @@ Members of KSC may abstain from a vote. Abstaining members will only be consider
 Issues that impacts the KSC governance requires a special decision process. Issues include:
 - Changes to the KSC charter
 - KSC voting rules
+- Election rules
 
 The issue may pass with 70% of the members (rounded up) of the committee supporting it.
+
+At most 1 KSC member from the same organization may cast a vote. Example: if KSC is made up of employees from organizations A, A, B, C, D, then orgnaization A may cast 1 vote through either employee. There would be a total of 4 votes, and 3 votes (70% rounded up) is required to pass a proposal. This rule is designed to remove organization A's ability to defeat a proposal that is supported by all other KSC members.
 
 ### Results
 

--- a/KUBEFLOW-STEERING-COMMITTEE.md
+++ b/KUBEFLOW-STEERING-COMMITTEE.md
@@ -76,7 +76,9 @@ Issues that impacts the KSC governance requires a special decision process. Issu
 
 The issue may pass with 70% of the members (rounded up) of the committee supporting it.
 
-At most 1 KSC member from the same organization may cast a vote. Example: if KSC is made up of employees from organizations A, A, B, C, D, then orgnaization A may cast 1 vote through either employee. There would be a total of 4 votes, and 3 votes (70% rounded up) is required to pass a proposal. This rule is designed to remove organization A's ability to defeat a proposal that is supported by all other KSC members.
+One organization may cast 1 vote. Votes cast by members from the same organization are equally weighted. Example:
+- If KSC is made up of employees from organizations A, A, B, C, D, each vote from organization A is weighted by a factor of 0.5. The total number of votes is 4, and 3 votes (70% rounded up) is required to pass a proposal. This rule is designed to remove organization A's ability to defeat a proposal that is supported by all other KSC members.
+- Similarly, if KSC is made up of employees from organizations A, A, B, B, C, the total number of votes is 3, and 2.5 votes is required to pass a proposal. 
 
 ### Results
 


### PR DESCRIPTION
This proposal was discussed together with #786 (1 seat per organization) in KSC, where majority felt the 2 rules will encourage diversity of the KSC committee.

2 members from the same organization on KSC may give that organization the power to veto any governance change proposals, under the 70% rule for passing such proposals. In an ideal world, each KSC member should act and vote individually and according to the best interest of the Kubeflow project. However, KSC recognize that an organization may have strong influence their representatives in KSC. This rule is designed to prevent one organization from being able to reject proposals.

In the case where KSC is made up of members from 3 organizations (i.e. organizations A, A, B, B, C), then the 3 votes will need to be unanimous to pass a proposal.

In the case where 2 members from the same organization have different opinions, this rule does not provide any guidance on resolving the conflict.

If #786 is passed, this rule will not have any effect to the 2026 KSC and thereafter, since the KSC will have representation from 5 different organizations. This rule may still be kept to in case new proposal revert #786.