### PR TITLE
Make Notebooks WG meeting weekly

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -104,7 +104,7 @@
   name: Kubeflow Notebooks 2.0 + WG Meeting (US + EMEA)
   date: 06/08/2023
   time: 8:00AM-8:55AM
-  frequency: bi-weekly
+  frequency: weekly
   video: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
   attendees:
     - email: kubeflow-discuss@googlegroups.com


### PR DESCRIPTION
As we have way to much to discuss in the Notebooks meetings right now (due to Notebook 2.0) we are moving the meeting to weekly, rather than bi-weekly.

It will still be at the same time of 8am PT each Thursday.