### PR TITLE
chore: add trademark disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ please reach out to ksc@kubeflow.org.
 
 * [proposals](https://github.com/kubeflow/community/tree/master/proposals): Kubeflow design proposals
 * [how-to](https://github.com/kubeflow/community/tree/master/how-to): for documenting community and other project processes
+
+## Legal
+
+The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/).


### PR DESCRIPTION
According to [kubeflow/website #3664](https://github.com/kubeflow/website/issues/3664) and [clomonitor.io](https://clomonitor.io/projects/cncf/kubeflow#community) this readme should have a trademark disclaimer.
