### PR TITLE
chore: revert legal disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,3 @@ please reach out to ksc@kubeflow.org.
 
 * [proposals](https://github.com/kubeflow/community/tree/master/proposals): Kubeflow design proposals
 * [how-to](https://github.com/kubeflow/community/tree/master/how-to): for documenting community and other project processes
-
-## Legal
-
-The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/trademark-usage/).


### PR DESCRIPTION
PR #816 did not have the intended effect, so it should be reverted.

Signed-off-by: Paul Boyd <pboyd@redhat.com>
