### PR TITLE
Adding GSOC project proposal template for the use by GSoC contributors

### DIFF
--- a/proposals/gsoc/gsoc-proposal-template.md
+++ b/proposals/gsoc/gsoc-proposal-template.md
@@ -1,0 +1,71 @@
+# Project Title
+
+[Provide a exact same title for your project from the proposals page; including the project number as is]
+
+## Summary
+
+[Offer a brief summary of your project, highlighting the problem it addresses, your proposed solution, and the anticipated impact.]
+
+## Personal Information
+
+- **Full Name**: [Your Full Name]
+- **Email Address**: [Your Email Address]
+- **GitHub Profile**: [Your GitHub Profile URL]
+- **LinkedIn**: [Your LinkedIn Profile URL]
+- **University/College**: [Your University/College Name]
+- **Degree Program**: [Your Degree Program]
+- **Year of Study**: [Your Current Year of Study]
+- **Country of Residence**: [Your Country]
+- **Timezone**: [Your Timezone, also note difference from UTC]
+
+## Qualifications; Motivation?
+
+[Highlight your relevant skills, experiences, and qualifications that make you a suitable candidate for this project. Mention any previous work, open-source contributions, or academic achievements that showcase your capabilities. List any/all contributions to Kubeflow community so far.]
+
+[Be clear about your availability and time commitment. State the number of hours per week you plan to dedicate to the project (recommended: 30-40 hours). Mention any potential conflicts (e.g., exams, vacations) and how you plan to address them. It is important to manage expectations upfront and explain how you will manage your time effectively to meet the project deadlines.]
+
+[motivation about why you are interested in working on the project.]
+
+## Goals
+
+[List the specific goals you aim to achieve during the GSoC coding period. Be clear and concise. Example: Implement feature X in library Y., Example: Improve the performance of module Z by N%.]
+
+## Non-Goals
+
+[Clearly state what is *out* of scope for this project. This helps manage expectations. Example: This project will not include integration with service A., Example: We will not be addressing issue B during this GSoC project.]
+
+## Technical Details
+
+[Provide an in-depth description of your project's technical aspects. This should include the technologies, programming languages, frameworks, and tools you plan to use. Discuss any potential challenges and how you intend to address them.]
+
+## Test Plan
+
+[Describe how you plan to test your code to ensure its quality and correctness.]
+
+## Estimation of Deliverables
+
+[Present a rough timeline of your project, breaking down each goals with estimated times in weeks. The below is just a sample; modify to fit your needs]
+
+- **Milestone 1**: [Description of the first milestone]
+
+- **Milestone 2**: [Description of the second milestone]
+    
+- **Milestone 3**: [Description of the third milestone]
+
+[   
+ This below is the timeline set out by the Google for GSoC 2025, if possible try to align major deliverables around the dates but not required
+
+    - May 8 - June 1: Community Bonding Period 
+    - June 2 : Coding officially begins!
+    - July 14 : GSoC contributors can begin submitting midterm evaluations (for standard 12 week coding projects)
+    - August 25 - September 1: GSoC contributors submit their final work product
+]
+
+## Additional Notes (Optional)
+
+[Include any other information you think is relevant to your application.]
+
+
+
+
+


### PR DESCRIPTION
This template moved from https://github.com/kubeflow/website/pull/4060 to here for long-term support and also so that contributors can download it.