### PR TITLE
Update ADOPTERS with links for each project

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,9 +6,9 @@ It's a small contribution with a big impact!
 
 We invite you to add your organization to these lists by raising a pull request on the relevant GitHub repository.
 
-## Adopters of Kubeflow Components
+## Adopters of Kubeflow Projects
 
-For adopters of specific Kubeflow components, please refer to the respective component's repository.
+For adopters of specific Kubeflow Projects, please refer to the respective component's repository.
 
 | Component               | Repository                                                              | Adopter List                                                                            |
 |-------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,23 +1,34 @@
-# Adopters of Kubeflow Project
+# Adopters of Kubeflow
 
-Below are the adopters of Kubeflow. If you are using Kubeflow please add
-yourself into the following list by a pull request. Please keep the list in
-alphabetical order.
+Our adopter files list organizations that have adopted Kubeflow in some way.
+Sharing your adoption helps build project momentum, and this benefits everyone.
+It's a small contribution with a big impact!
 
-| Organization | Contact | Description of Use |
-| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [DHL Data & Analytics](https://www.linkedin.com/company/dhl-data-analytics/) | [@juliusvonkohout](https://github.com/juliusvonkohout)                                                                                   | Kubeflow is used as our main ML platform.                                 |
-| [CERN](https://www.home.cern)                                       | [@gigabyte132](https://github.com/gigabyte132) | Kubeflow is used as our main ML platform.    |
-| [Telia](https://www.teliacompany.com/)                                       | [@akeed](https://github.com/akeed), [@sarahberenji](https://github.com/sarahberenji), [@tarekabouzeid](https://github.com/tarekabouzeid) | Kubeflow is used as our main ML platform for on-premises analytics.       |
+We invite you to add your organization to these lists by raising a pull request on the relevant GitHub repository.
 
-# Adopters of Individual Kubeflow Components
+## Adopters of Kubeflow Components
 
-Here is the list of adopters for various Kubeflow components. If you are using
-some of these Kubeflow components, please update the files by a pull request
-in the corresponding GitHub repositories.
+For adopters of specific Kubeflow components, please refer to the respective component's repository.
 
-- Adopters of [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md).
+| Component               | Repository                                                              | Adopter List                                                                            |
+|-------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| Kubeflow Katib          | [`kubeflow/katib`](https://github.com/kubeflow/katib)                   | [`ADOPTERS.md`](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md)              |
+| Kubeflow MPI Operator   | [`kubeflow/mpi-operator`](https://github.com/kubeflow/mpi-operator)     | [`ADOPTERS.md`](https://github.com/kubeflow/mpi-operator/blob/master/ADOPTERS.md)       |
+| Kubeflow Model Registry | [`kubeflow/model-registry`](https://github.com/kubeflow/model-registry) | TBA                                                                                     |
+| Kubeflow Notebooks      | [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks)           | TBA                                                                                     |
+| Kubeflow Pipelines      | [`kubeflow/pipelines`](https://github.com/kubeflow/pipelines)           | TBA                                                                                     |
+| Kubeflow Spark Operator | [`kubeflow/spark-operator`](https://github.com/kubeflow/spark-operator) | [`ADOPTERS.md`](https://github.com/kubeflow/spark-operator/blob/master/ADOPTERS.md)     |
+| Kubeflow Trainer        | [`kubeflow/trainer`](https://github.com/kubeflow/trainer)               | [`ADOPTERS.md`](https://github.com/kubeflow/training-operator/blob/master/ADOPTERS.md)  |
+| KServe                  | [`kserve/kserve`](https://github.com/kserve/kserve)                     | [`ADOPTERS.md`](https://github.com/kserve/website/blob/main/docs/community/adopters.md) |
 
-- Adopters of [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator/blob/master/ADOPTERS.md).
+## Adopters of Kubeflow Platform
 
-- Adopters of [Kubeflow Training Operator](https://github.com/kubeflow/training-operator/blob/master/ADOPTERS.md).
+For organizations that have adopted Kubeflow Platform, please add your organization to the following list.
+<br>
+Please keep the list in alphabetical order.
+
+| Organization                                                                 | Contact                                                                                                                                  | Description of Use                                                  |
+|------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [CERN](https://www.home.cern)                                                | [@gigabyte132](https://github.com/gigabyte132)                                                                                           | Kubeflow is used as our main ML platform.                           |
+| [DHL Data & Analytics](https://www.linkedin.com/company/dhl-data-analytics/) | [@juliusvonkohout](https://github.com/juliusvonkohout)                                                                                   | Kubeflow is used as our main ML platform.                           |
+| [Telia](https://www.teliacompany.com/)                                       | [@akeed](https://github.com/akeed), [@sarahberenji](https://github.com/sarahberenji), [@tarekabouzeid](https://github.com/tarekabouzeid) | Kubeflow is used as our main ML platform for on-premises analytics. |


### PR DESCRIPTION
This PR updates the `ADOPTERS.md` with links to the adopter files for each component.

Note, I have left "TBA" for the ones which don't yet have independent files (Model Registry, Notebooks, Pipelines).

Also, I have moved these links to the top, so that as the platform list grows, it does not hide the component-specific links.