### PR TITLE
Update calendar.yaml

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -93,6 +93,7 @@
   timezone: Europe/Madrid
   frequency: bi-weekly
   video: https://meet.google.com/ezk-fmxo-fvu
+  until: 06/24/2025
   attendees:
     - email: kubeflow-discuss@googlegroups.com
   description:


### PR DESCRIPTION
Update Release Team meetings to be paused for the moment. See more information about this decision  on Slack kubeflow announcement and discussions on Kubeflow Manifests channel.
The meetings are planned to return after CNCF graduation