### PR TITLE
chore(docs): Update Kubeflow Maintainers Doc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ The Kubeflow projects approvers and reviewers can be found in the corresponding 
 
 - [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/OWNERS)
 - [Kubeflow Manifests](https://github.com/kubeflow/manifests/blob/master/OWNERS)
-- [Kubeflow Model Registry](https://github.com/kubeflow/model-registry/blob/master/OWNERS)
+- [Kubeflow Model Registry](https://github.com/kubeflow/model-registry/blob/main/OWNERS)
 - [Kubeflow Notebooks](https://github.com/kubeflow/notebooks/blob/main/OWNERS)
 - [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/OWNERS)
 - [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator/blob/master/OWNERS)


### PR DESCRIPTION
I updated the MAINTAINER list which is required for CNCF Graduation: https://github.com/kubeflow/community/issues/858


/cc @kubeflow/kubeflow-steering-committee @kubeflow/wg-training-leads @kubeflow/wg-pipeline-leads @kubeflow/wg-notebooks-leads @kubeflow/wg-manifests-leads @kubeflow/wg-data-leads @jacobsalway @vara-bonthu @yuchaoran2011   @chensun @droctothorpe @HumairAK @james-jwu @mprahl @zazulam @Electronic-Waste @astefanutti @varodrig @tarekabouzeid 