### PR TITLE
Proposal: Donate Kale to Kubeflow

### DIFF
--- a/proposals/kale-donation.md
+++ b/proposals/kale-donation.md
@@ -97,7 +97,7 @@ In the longer term, Kale will be extended to cover other key integrations, inclu
 - Number of Contributors: 6 on the last 3 months
 - Number of Users: N/A (no recent release)
 - Number of Forks: 132
-- Number of Stars: 141
+- Number of Stars: 649
 - Number of package/project installations/downloads:  N/A (no recent release)
 
 ## Kubeflow Checklist


### PR DESCRIPTION
[Kale](https://github.com/kubeflow-kale/kale) has a long history with Kubeflow, dating back to 2019. Kale provides the means to deploy Kubeflow pipelines directly from the Jupyter notebook UI, without ever leaving the IDE.

Kale is an essential part of the newly established ML Experience Working Group charter.

Kale was abandoned in 2022, but with the GSoC 25 program we updated the project to work on the most recent version of JupyterLab and Kubeflow Pipelines. We have now 6 active maintainers who are collaborating on the project, and an established roadmap for the next few months. You can find more details in the PR's doc.

Related issues:
- https://github.com/kubeflow/community/issues/730
- https://github.com/kubeflow/community/issues/808

cc @ederign 