### PR TITLE
Disable meetings in Kubeflow calendar

### DIFF
--- a/calendar/calendar.yaml
+++ b/calendar/calendar.yaml
@@ -24,200 +24,200 @@
 ####################################################################################################
 # Current meetings
 ####################################################################################################
-- id: kf032
-  name: Kubeflow Community Call
-  date: 04/15/2025
-  time: 8:00AM-8:55AM
-  frequency: bi-weekly
-  video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & agenda: https://bit.ly/kf-meeting-notes
+# - id: kf032
+#   name: Kubeflow Community Call
+#   date: 04/15/2025
+#   time: 8:00AM-8:55AM
+#   frequency: bi-weekly
+#   video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & agenda: https://bit.ly/kf-meeting-notes
 
-      Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
-      Meeting ID: 991 5242 7566
-      Passcode: 645928
+#       Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+#       Meeting ID: 991 5242 7566
+#       Passcode: 645928
 
-      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
-      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+#       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+#       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
-      Meeting Host Link: https://zoom.us/s/99152427566
-  organizer: autobot@kubeflow.org
+#       Meeting Host Link: https://zoom.us/s/99152427566
+#   organizer: autobot@kubeflow.org
 
-- id: kf043
-  name: Kubeflow CNCF Graduation Call
-  date: 04/22/2025
-  time: 8:00AM-8:55AM
-  frequency: bi-weekly
-  video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & agenda: https://bit.ly/kf-meeting-notes
+# - id: kf043
+#   name: Kubeflow CNCF Graduation Call
+#   date: 04/22/2025
+#   time: 8:00AM-8:55AM
+#   frequency: bi-weekly
+#   video: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & agenda: https://bit.ly/kf-meeting-notes
 
-      Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
-      Meeting ID: 991 5242 7566
-      Passcode: 645928
+#       Join with Zoom: https://zoom.us/j/99152427566?pwd=S0djc1FPcXkyNUdneHg3UFR3VTcyQT09
+#       Meeting ID: 991 5242 7566
+#       Passcode: 645928
 
-      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
-      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+#       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+#       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
-      Meeting Host Link: https://zoom.us/s/99152427566
-  organizer: autobot@kubeflow.org
+#       Meeting Host Link: https://zoom.us/s/99152427566
+#   organizer: autobot@kubeflow.org
 
-- id: kf026
-  name: Kubeflow Pipelines Community Meeting (PST AM)
-  date: 08/19/2020
-  time: 10:00am-10:40am
-  frequency: bi-weekly
-  video: https://zoom.us/j/92607298595?pwd=VlKLUbiguGkbT9oKbaoDmCxrhbRop7.1
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-    - email: kubeflow-pipelines@google.com
-  description:
-    - |
-      Notes & Agenda: http://bit.ly/kfp-meeting-notes
-      Join Zoom Meeting
-      https://zoom.us/j/92607298595?pwd=VlKLUbiguGkbT9oKbaoDmCxrhbRop7.1
-      Meeting ID: 926 0729 8595
-      Passcode: 876287
-  organizer: chensun
+# - id: kf026
+#   name: Kubeflow Pipelines Community Meeting (PST AM)
+#   date: 08/19/2020
+#   time: 10:00am-10:40am
+#   frequency: bi-weekly
+#   video: https://zoom.us/j/92607298595?pwd=VlKLUbiguGkbT9oKbaoDmCxrhbRop7.1
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#     - email: kubeflow-pipelines@google.com
+#   description:
+#     - |
+#       Notes & Agenda: http://bit.ly/kfp-meeting-notes
+#       Join Zoom Meeting
+#       https://zoom.us/j/92607298595?pwd=VlKLUbiguGkbT9oKbaoDmCxrhbRop7.1
+#       Meeting ID: 926 0729 8595
+#       Passcode: 876287
+#   organizer: chensun
 
-- id: kf035
-  name: Kubeflow Release Team Meeting (CET, US friendly)
-  date: 05/15/2023
-  time: 6:00PM-7:00PM
-  timezone: Europe/Madrid
-  frequency: bi-weekly
-  video: https://meet.google.com/ezk-fmxo-fvu
-  until: 06/24/2025
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & agenda: https://bit.ly/kf-release-team-notes
+# - id: kf035
+#   name: Kubeflow Release Team Meeting (CET, US friendly)
+#   date: 05/15/2023
+#   time: 6:00PM-7:00PM
+#   timezone: Europe/Madrid
+#   frequency: bi-weekly
+#   video: https://meet.google.com/ezk-fmxo-fvu
+#   until: 06/24/2025
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & agenda: https://bit.ly/kf-release-team-notes
 
-      Join with Google Meet: https://meet.google.com/ezk-fmxo-fvu
-      Time zone: Europe/Madrid
-      Video call link: https://meet.google.com/ezk-fmxo-fvu
-      Or dial: (ES) +34 877 99 40 20 PIN: 889 929 201#
-      More phone numbers: https://tel.meet/ezk-fmxo-fvu?pin=9345506892998
-  organizer: dnplas
+#       Join with Google Meet: https://meet.google.com/ezk-fmxo-fvu
+#       Time zone: Europe/Madrid
+#       Video call link: https://meet.google.com/ezk-fmxo-fvu
+#       Or dial: (ES) +34 877 99 40 20 PIN: 889 929 201#
+#       More phone numbers: https://tel.meet/ezk-fmxo-fvu?pin=9345506892998
+#   organizer: dnplas
 
-- id: kf036
-  name: Kubeflow Platform Meeting (Manifests + Security WG)
-  date: 06/01/2023
-  time: 6:00PM-7:00PM
-  timezone: Europe/Athens
-  frequency: bi-weekly
-  video: https://bit.ly/kf-wg-manifests-meet
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/kf-wg-manifests-notes
-      Meeting Link: https://bit.ly/kf-wg-manifests-meet
-      Recordings: https://bit.ly/kf-wg-manifests-drive
-  organizer: juliusvonkohout
+# - id: kf036
+#   name: Kubeflow Platform Meeting (Manifests + Security WG)
+#   date: 06/01/2023
+#   time: 6:00PM-7:00PM
+#   timezone: Europe/Athens
+#   frequency: bi-weekly
+#   video: https://bit.ly/kf-wg-manifests-meet
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & Agenda: https://bit.ly/kf-wg-manifests-notes
+#       Meeting Link: https://bit.ly/kf-wg-manifests-meet
+#       Recordings: https://bit.ly/kf-wg-manifests-drive
+#   organizer: juliusvonkohout
 
-- id: kf037
-  name: Kubeflow Notebooks 2.0 + WG Meeting (US + EMEA)
-  date: 06/08/2023
-  time: 8:00AM-8:55AM
-  frequency: weekly
-  video: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
+# - id: kf037
+#   name: Kubeflow Notebooks 2.0 + WG Meeting (US + EMEA)
+#   date: 06/08/2023
+#   time: 8:00AM-8:55AM
+#   frequency: weekly
+#   video: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & Agenda: https://bit.ly/kf-notebooks-wg-notes
 
-      Join with Zoom: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
-      Meeting ID: 969 6799 6819
-      Passcode: 326059
+#       Join with Zoom: https://zoom.us/j/96967996819?pwd=aFNkWnBTVW1TWW1iellneFYrRXJPdz09
+#       Meeting ID: 969 6799 6819
+#       Passcode: 326059
 
-      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
-      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
-  organizer: kimwnasptd
+#       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+#       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+#   organizer: kimwnasptd
 
-- id: kf041
-  name: KF Model Registry community meeting (US/EMEA)
-  date: 02/19/2024
-  time: 7:00PM-8:00PM
-  timezone: Europe/Madrid
-  # meeting to happen after KF Release meeting (id: kf035), hence align by using same TZ
-  frequency: bi-weekly
-  video: https://meet.google.com/pni-ywgg-gtt
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Bi-weekly recurring meeting for KF Model Registry community call
+# - id: kf041
+#   name: KF Model Registry community meeting (US/EMEA)
+#   date: 02/19/2024
+#   time: 7:00PM-8:00PM
+#   timezone: Europe/Madrid
+#   # meeting to happen after KF Release meeting (id: kf035), hence align by using same TZ
+#   frequency: bi-weekly
+#   video: https://meet.google.com/pni-ywgg-gtt
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Bi-weekly recurring meeting for KF Model Registry community call
 
-      Meeting notes: https://docs.google.com/document/d/1DmMhcae081SItH19gSqBpFtPfbkr9dFhSMCgs-JKzNo/edit?usp=sharing
-  organizer: tarilabs
+#       Meeting notes: https://docs.google.com/document/d/1DmMhcae081SItH19gSqBpFtPfbkr9dFhSMCgs-JKzNo/edit?usp=sharing
+#   organizer: tarilabs
 
-- id: kf042
-  name: Kubeflow Spark Operator Meeting
-  date: 03/07/2025
-  time: 8:00AM-9:00AM
-  frequency: bi-weekly
-  video: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Monthly recurring meeting for Kubeflow Spark Operator.
+# - id: kf042
+#   name: Kubeflow Spark Operator Meeting
+#   date: 03/07/2025
+#   time: 8:00AM-9:00AM
+#   frequency: bi-weekly
+#   video: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Monthly recurring meeting for Kubeflow Spark Operator.
 
-      Notes & Agenda: https://docs.google.com/document/d/1AnG6ptKLBY7O6ddyNm4SVsEbfu6jiyVyN3hDDgDUnxQ/edit?usp=sharing
+#       Notes & Agenda: https://docs.google.com/document/d/1AnG6ptKLBY7O6ddyNm4SVsEbfu6jiyVyN3hDDgDUnxQ/edit?usp=sharing
 
-      Join with Zoom: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
-      Meeting ID: 938 7060 2975
-      Passcode: 307820
+#       Join with Zoom: https://zoom.us/j/93870602975?pwd=NWFNT2xrZU03alVTTXFBTEsvdDdMQT09
+#       Meeting ID: 938 7060 2975
+#       Passcode: 307820
 
-      Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
-      International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
+#       Join with Phone (USA): +1 669 900 6833 or +1 646 558 8656
+#       International numbers: https://zoom.us/zoomconference?m=Os1EjlUlpb2_XUMaQ6dX1azqMK5CkfWH
 
-  organizer: vara-bonthu
+#   organizer: vara-bonthu
 
-- id: kf038
-  name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)
-  date: 09/20/2023
-  time: 2:00PM-3:00PM
-  timezone: Etc/UTC
-  frequency: every-4-weeks
-  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/2PWVCkV
+# - id: kf038
+#   name: Kubeflow AutoML and Training WG Meeting (Asia & Europe friendly)
+#   date: 09/20/2023
+#   time: 2:00PM-3:00PM
+#   timezone: Etc/UTC
+#   frequency: every-4-weeks
+#   video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & Agenda: https://bit.ly/2PWVCkV
 
-      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-      Meeting ID: 839 443 5453
-      Passcode: R3ScM7
-  organizer: andreyvelich
+#       Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+#       Meeting ID: 839 443 5453
+#       Passcode: R3ScM7
+#   organizer: andreyvelich
 
-- id: kf039
-  name: Kubeflow AutoML and Training WG Meeting (US friendly)
-  date: 10/04/2023
-  time: 5:00PM-6:00PM
-  timezone: Etc/UTC
-  frequency: every-4-weeks
-  video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-  attendees:
-    - email: kubeflow-discuss@googlegroups.com
-  description:
-    - |
-      Notes & Agenda: https://bit.ly/2PWVCkV
+# - id: kf039
+#   name: Kubeflow AutoML and Training WG Meeting (US friendly)
+#   date: 10/04/2023
+#   time: 5:00PM-6:00PM
+#   timezone: Etc/UTC
+#   frequency: every-4-weeks
+#   video: https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+#   attendees:
+#     - email: kubeflow-discuss@googlegroups.com
+#   description:
+#     - |
+#       Notes & Agenda: https://bit.ly/2PWVCkV
 
-      Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
-      Meeting ID: 839 443 5453
-      Passcode: R3ScM7
-  organizer: andreyvelich
+#       Join Zoom Meeting https://us04web.zoom.us/j/8394435453?pwd=SHo4QXJhdHltb043NGxnMkZmU1l0UT09
+#       Meeting ID: 839 443 5453
+#       Passcode: R3ScM7
+#   organizer: andreyvelich
 
 ####################################################################################################
 # Legacy meetings


### PR DESCRIPTION
Since we migrated to LFX calendar, we can comment out all meetings in the legacy Kubeflow calendar.
That will ensure our automation won't add them back to the calendar.


/assign @thesuperzapper @kubeflow/kubeflow-steering-committee 