### PR TITLE
chore: rename model-registry to hub

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,7 +14,7 @@ For adopters of specific Kubeflow Projects, please refer to the respective compo
 |-------------------------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
 | Kubeflow Katib          | [`kubeflow/katib`](https://github.com/kubeflow/katib)                   | [`ADOPTERS.md`](https://github.com/kubeflow/katib/blob/master/ADOPTERS.md)              |
 | Kubeflow MPI Operator   | [`kubeflow/mpi-operator`](https://github.com/kubeflow/mpi-operator)     | [`ADOPTERS.md`](https://github.com/kubeflow/mpi-operator/blob/master/ADOPTERS.md)       |
-| Kubeflow Model Registry | [`kubeflow/model-registry`](https://github.com/kubeflow/model-registry) | [`ADOPTERS.md`](https://github.com/kubeflow/model-registry/blob/master/ADOPTERS.md)     |
+| Kubeflow Hub            | [`kubeflow/hub`](https://github.com/kubeflow/hub)                       | [`ADOPTERS.md`](https://github.com/kubeflow/hub/blob/master/ADOPTERS.md)     |
 | Kubeflow Notebooks      | [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks)           | [`ADOPTERS.md`](https://github.com/kubeflow/notebooks/blob/main/ADOPTERS.md)            |
 | Kubeflow Pipelines      | [`kubeflow/pipelines`](https://github.com/kubeflow/pipelines)           | [`ADOPTERS.md`](https://github.com/kubeflow/pipelines/blob/master/ADOPTERS.md)          |
 | Kubeflow Spark Operator | [`kubeflow/spark-operator`](https://github.com/kubeflow/spark-operator) | [`ADOPTERS.md`](https://github.com/kubeflow/spark-operator/blob/master/ADOPTERS.md)     |

--- a/KUBEFLOW-GENERAL-TECHNICAL-REVIEW.md
+++ b/KUBEFLOW-GENERAL-TECHNICAL-REVIEW.md
@@ -67,7 +67,7 @@ For more information, check ROADMAP for each Kubeflow Project:
 - [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator/blob/master/ROADMAP.md)
 - [Kubeflow Trainer](https://github.com/kubeflow/trainer/blob/master/ROADMAP.md)
 - [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/ROADMAP.md)
-- [Kubeflow Model Registry](https://github.com/kubeflow/model-registry/blob/main/ROADMAP.md)
+- [Kubeflow Hub](https://github.com/kubeflow/hub/blob/main/ROADMAP.md)
 - [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/ROADMAP.md)
 
 Community-wide changes are proposed as [Kubeflow Enhancement proposals (KEPs)](https://github.com/kubeflow/community/tree/master/proposals)
@@ -262,7 +262,7 @@ The API is documented using swagger and examples about its usage
 - Kubeflow Model Registry
 
 Model Registry REST API is available under the `/api/model_registry/` HTTP path. More information
-[can be found here](https://www.kubeflow.org/docs/components/model-registry/reference/rest-api/)
+[can be found here](https://www.kubeflow.org/docs/components/hub/reference/rest-api/)
 
 The Model Catalog Service provides a read-only discovery service for ML models across multiple
 catalog sources. It acts as a federated metadata aggregation layer, allowing users to search and

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ The Kubeflow projects approvers and reviewers can be found in the corresponding 
 
 - [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/OWNERS)
 - [Kubeflow Manifests](https://github.com/kubeflow/manifests/blob/master/OWNERS)
-- [Kubeflow Model Registry](https://github.com/kubeflow/model-registry/blob/main/OWNERS)
+- [Kubeflow Hub](https://github.com/kubeflow/hub/blob/main/OWNERS)
 - [Kubeflow Notebooks](https://github.com/kubeflow/notebooks/blob/main/OWNERS)
 - [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/OWNERS)
 - [Kubeflow SDK](https://github.com/kubeflow/sdk/blob/main/OWNERS)

--- a/wg-data/charter.md
+++ b/wg-data/charter.md
@@ -19,7 +19,7 @@ For example: Data Preparation, Feature Store, and Model Registry have been recen
 - Onboarding and maintenance of the Spark operator for scalable and distributed data processing.
 [See also](https://github.com/kubeflow/spark-operator)
 - Continued development of the Model Registry to manage and version machine learning models efficiently.
-[See also](https://github.com/kubeflow/model-registry)
+[See also](https://github.com/kubeflow/hub)
   - Model Registry REST server
   - Model Registry Python client
   - deployment Manifests

--- a/wgs.yaml
+++ b/wgs.yaml
@@ -192,9 +192,9 @@ workinggroups:
     - name: wg-data-leads
       description: Team of Data Working Group leads
   subprojects:
-  - name: model-registry
+  - name: hub
     owners:
-    - https://raw.githubusercontent.com/kubeflow/model-registry/main/OWNERS
+    - https://raw.githubusercontent.com/kubeflow/hub/main/OWNERS
   - name: spark-operator
     owners:
     - https://raw.githubusercontent.com/kubeflow/spark-operator/blob/master/OWNERS


### PR DESCRIPTION
Replace references to kubeflow/model-registry with kubeflow/hub
