### PR TITLE
chore: updates for kubeflow-hub slack channel

### DIFF
--- a/security/self-assessment.md
+++ b/security/self-assessment.md
@@ -446,7 +446,7 @@ practices and is following the OpenSSF Best Practices. Kubeflow projects achieve
   - `#kubeflow-notebooks`
   - `#kubeflow-trainer`
   - `#kubeflow-katib`
-  - `#kubeflow-model-registry`
+  - `#kubeflow-hub`
   - `#kubeflow-pipelines`
 
 - Kubeflow Working Groups host weekly community meetings: https://www.kubeflow.org/docs/about/community/#list-of-available-meetings


### PR DESCRIPTION
Following the rename of Kubeflow Model Registry to Kubeflow Hub, the slack channel #kubeflow-model-registry is updated to #kubeflow-hub

The renaming PR:
https://github.com/kubeflow/community/pull/907#pullrequestreview-3608586640