### PR TITLE
chore: Add per-WG `OWNERS` files

### DIFF
--- a/wg-data/OWNERS
+++ b/wg-data/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - wg-data-leads

--- a/wg-ml-experience/OWNERS
+++ b/wg-ml-experience/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - wg-ml-experience-leads

--- a/wg-notebooks/OWNERS
+++ b/wg-notebooks/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - wg-notebooks-leads

--- a/wg-pipelines/OWNERS
+++ b/wg-pipelines/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - wg-pipelines-leads

--- a/wg-training/OWNERS
+++ b/wg-training/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - wg-training-leads


### PR DESCRIPTION
This aims to add WG Leads as reviewers for their charters so that they
are aware of changes concerning their charter and readme.

This is in line with the process as outlined in `committee-steering/wg-governance.md`:

> For minor updates that only impact issues or areas within the scope of the WG, the WG Chairs _SHOULD_ facilitate the change.
