### PR TITLE
Appoint 2026 Vendor Representatives to the KDC

### DIFF
--- a/committee-distribution/README.md
+++ b/committee-distribution/README.md
@@ -12,11 +12,11 @@ The current membership of the committee is (listed alphabetically by first name)
 
 ### Vendor Representatives
 
-| Name                   | Organization | GitHub                                                          |
-| ---------------------- | ------------ | --------------------------------------------------------------- |
-| Francisco Javier Arceo | Red Hat      | [franciscojavierarceo](https://github.com/franciscojavierarceo) |
-| Rob Gibbon             | Canonical    | [grobbie](https://github.com/grobbie)                           |
-| Vikas Saxena           | RAICS.AI     | [vikas-saxena02](https://github.com/vikas-saxena02)             |
+| Name                   | Organization | GitHub                                                          | Term Start | Term End   |
+|------------------------|--------------|-----------------------------------------------------------------|------------|------------|
+| Francisco Javier Arceo | Red Hat      | [franciscojavierarceo](https://github.com/franciscojavierarceo) | 2026-07-17 | 2027-07-17 |
+| Rob Gibbon             | Canonical    | [grobbie](https://github.com/grobbie)                           | 2026-07-17 | 2027-07-17 |
+| Vikas Saxena           | RAICS.AI     | [vikas-saxena02](https://github.com/vikas-saxena02)             | 2026-07-17 | 2027-07-17 |
 
 ### Kubeflow Community Distribution Representatives
 

--- a/committee-distribution/README.md
+++ b/committee-distribution/README.md
@@ -13,10 +13,10 @@ The current membership of the committee is (listed alphabetically by first name)
 ### Vendor Representatives
 
 | Name                   | Organization | GitHub                                                          | Term Start | Term End   |
-|------------------------|--------------|-----------------------------------------------------------------|------------|------------|
-| Francisco Javier Arceo | Red Hat      | [franciscojavierarceo](https://github.com/franciscojavierarceo) | 2026-07-17 | 2027-07-17 |
-| Rob Gibbon             | Canonical    | [grobbie](https://github.com/grobbie)                           | 2026-07-17 | 2027-07-17 |
-| Vikas Saxena           | RAICS.AI     | [vikas-saxena02](https://github.com/vikas-saxena02)             | 2026-07-17 | 2027-07-17 |
+| ---------------------- | ------------ | --------------------------------------------------------------- | ---------- | ---------- |
+| Francisco Javier Arceo | Red Hat      | [franciscojavierarceo](https://github.com/franciscojavierarceo) | 07/17/2026 | 07/17/2027 |
+| Rob Gibbon             | Canonical    | [grobbie](https://github.com/grobbie)                           | 07/17/2026 | 07/17/2027 |
+| Vikas Saxena           | RAICS.AI     | [vikas-saxena02](https://github.com/vikas-saxena02)             | 07/17/2026 | 07/17/2027 |
 
 ### Kubeflow Community Distribution Representatives
 

--- a/committee-distribution/README.md
+++ b/committee-distribution/README.md
@@ -12,9 +12,11 @@ The current membership of the committee is (listed alphabetically by first name)
 
 ### Vendor Representatives
 
-| Name | Organization | GitHub |
-| ---- | ------------ | ------ |
-| TODO | TODO         | TODO   |
+| Name                   | Organization | GitHub                                                          |
+| ---------------------- | ------------ | --------------------------------------------------------------- |
+| Francisco Javier Arceo | Red Hat      | [franciscojavierarceo](https://github.com/franciscojavierarceo) |
+| Rob Gibbon             | Canonical    | [grobbie](https://github.com/grobbie)                           |
+| Vikas Saxena           | RAICS.AI     | [vikas-saxena02](https://github.com/vikas-saxena02)             |
 
 ### Kubeflow Community Distribution Representatives
 


### PR DESCRIPTION
Add 2026 vendor representative sits for Kubeflow Distribution Committee.

Recording from the public KSC vote: https://youtu.be/ER8X9vg9_Dk?t=546

@vikas-saxena02 @franciscojavierarceo and @grobbie, thanks again for your help with driving the Kubeflow Distributions forward!

cc @deusebio @kubeflow/kubeflow-outreach-committee 

/assign @franciscojavierarceo @chasecadet @thesuperzapper @juliusvonkohout 