### PR TITLE
Revise leads representatives and roles in README

### DIFF
--- a/committee-outreach/README.md
+++ b/committee-outreach/README.md
@@ -18,10 +18,11 @@ The current membership of the committee is (listed alphabetically by first name)
 
 ### Leads Representatives
 
-| Name            | Organization | GitHub                                        | Role              |
-| --------------- | ------------ | --------------------------------------------- | ----------------- |
-| Yash Pal        |              | [yashpal2104](https://github.com/yashpal2104) | Outreach Lead |
-| Dominik Kawka   |              | [dominikkawka](https://github.com/dominikkawka) | Outreach Lead |
+| Name            | Organization | GitHub                                          | Role          |
+| --------------- | ------------ | ----------------------------------------------- | --------------|
+| Yash Pal        | KLA          | [yashpal2104](https://github.com/yashpal2104)   | Outreach Lead |
+| Dominik Kawka   | Red Hat      | [dominikkawka](https://github.com/dominikkawka) | Outreach Lead |
+| Akash Jaiswal   | Oracle       | [jaiakash](https://github.com/jaiakash)         | Outreach Lead |
 
 ## Meetings
 

--- a/committee-outreach/README.md
+++ b/committee-outreach/README.md
@@ -18,9 +18,10 @@ The current membership of the committee is (listed alphabetically by first name)
 
 ### Leads Representatives
 
-| Name     | Organization | GitHub                                        | Role              |
-| -------- | ------------ | --------------------------------------------- | ----------------- |
-| Yash Pal |              | [yashpal2104](https://github.com/yashpal2104) | Social Media Lead |
+| Name            | Organization | GitHub                                        | Role              |
+| --------------- | ------------ | --------------------------------------------- | ----------------- |
+| Yash Pal        |              | [yashpal2104](https://github.com/yashpal2104) | Outreach Lead |
+| Dominik Kawka   |              | [dominikkawka](https://github.com/dominikkawka) | Outreach Lead |
 
 ## Meetings
 


### PR DESCRIPTION
Updated the role of Yash Pal to 'Outreach Lead' and added Dominik Kawka as an 'Outreach Lead'.